### PR TITLE
Brain_Data predict new functionality

### DIFF
--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -379,20 +379,28 @@ class Brain_Data(object):
         else:
             raise ValueError("view must be one of: 'axial', 'glass', 'mni', 'full'.")
 
-    def iplot(self, threshold=0, surface=False):
+    def iplot(self, threshold=0, surface=False, anatomical=None, **kwargs):
         """ Create an interactive brain viewer for the current brain data instance.
 
         Args:
             threshold (float/str): two-sided threshold to initialize the visualization, maybe be a percentile string; default 0
             surface (bool): whether to create a surface-based plot; default False
-            percentile_threshold (bool): whether to interpret threshold values as percentiles
+            anatomical: nifti image or filename to overlay
+            kwargs: optional arguments to nilearn.view_img or nilearn.view_img_on_surf
 
         Returns:
             interactive brain viewer widget
 
         """
-
-        return plot_interactive_brain(self, threshold=threshold, surface=surface)
+        if anatomical is not None:
+            if not isinstance(anatomical, nib.Nifti1Image):
+                if isinstance(anatomical, six.string_types):
+                    anatomical = nib.load(anatomical)
+                else:
+                    raise ValueError("anatomical is not a nibabel instance")
+        else:
+            anatomical = nib.load(resolve_mni_path(MNI_Template)['brain'])
+        return plot_interactive_brain(self, threshold=threshold, surface=surface, anatomical=anatomical, **kwargs)
 
     def regress(self, mode='ols', **kwargs):
         """ Run a mass-univariate regression across voxels. Three types of regressions can be run:

--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -45,7 +45,8 @@ from nltools.utils import (set_algorithm,
                            concatenate,
                            _bootstrap_apply_func,
                            set_decomposition_algorithm,
-                           check_brain_data)
+                           check_brain_data,
+                           _roi_func)
 from nltools.cross_validation import set_cv
 from nltools.plotting import scatterplot
 from nltools.stats import (pearson,
@@ -991,10 +992,8 @@ class Brain_Data(object):
             if len(rois_img.shape()) != 2:
                 raise ValueError("rois cannot be coerced into a mask. Make sure nifti file or Brain_Data is 3d with non-overlapping integer labels or 4d with non-overlapping boolean masks")
 
-            def _roi_func(brain, roi, algorithm, cv_dict, **kwargs):
-                return brain.apply_mask(roi).predict(algorithm=algorithm, cv_dict=cv_dict, plot=False, **kwargs)
-
             out = Parallel(n_jobs=n_jobs, verbose=verbose)(delayed(_roi_func)(self, r, algorithm, cv_dict, **kwargs) for r in rois_img)
+
         elif method == 'searchlight':
             # Searchlight
             if process_mask is None:

--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -859,7 +859,7 @@ class Brain_Data(object):
             for train, test in cv:
                 # Ensure estimators are always indepedent across folds
                 predictor_cv = clone(predictor_settings['predictor'])
-                predictor_cv.fit(self.data[train], self.Y.loc[train])
+                predictor_cv.fit(self.data[train], self.Y.iloc[train])
                 output['yfit_xval'][test] = predictor_cv.predict(self.data[test]).ravel()
                 if predictor_settings['prediction_type'] == 'classification':
                     if predictor_settings['algorithm'] not in ['svm', 'ridgeClassifier', 'ridgeClassifierCV']:
@@ -1462,7 +1462,7 @@ class Brain_Data(object):
 
         if function is 'predict':
             bootstrapped = [x['weight_map'] for x in bootstrapped]
-        bootstrapped = Brain_Data(bootstrapped)
+        bootstrapped = Brain_Data(bootstrapped, mask=self.mask)
         return summarize_bootstrap(bootstrapped, save_weights=save_weights)
 
     def decompose(self, algorithm='pca', axis='voxels', n_components=None,

--- a/nltools/plotting.py
+++ b/nltools/plotting.py
@@ -219,48 +219,6 @@ def plot_brain(objIn, how='full', thr_upper=None, thr_lower=None, **kwargs):
     del obj  # save memory
     return
 
-
-def iBrainViewer(objIn, statmin=-7, statmax=7, statstep=0.1, initThresh=2, figsize=(10, 5)):
-    """
-    Simple interactive brain plotting using ipython widgets.
-    Args:
-        objIn: 3d nifti image to plot
-        statmin: (float) minimum threshold for statistic value
-        statmax: (float) maximum threshold for statistic value
-        statstep (float) step size for thresholding
-        initThresh: (float) what stat value to initialize the plot with
-    """
-
-    warnings.warn("iBrainViewer is deprecated and will likely be removed in a future release. Use plot_interactive_brain instead", DeprecationWarning)
-
-    from ipywidgets import interact, fixed, widgets
-
-    interact(_iviewer, objIn=fixed(objIn),
-             x=widgets.IntSlider(min=-70, max=70, step=1, value=0, continuous_update=False),
-             y=widgets.IntSlider(min=-90, max=65, step=1, value=0, continuous_update=False),
-             z=widgets.IntSlider(min=-40, max=70, step=1, value=0, continuous_update=False),
-             stat=widgets.FloatSlider(min=statmin, max=statmax, step=statstep, value=initThresh, orientation='horizontal', continuous_update=False, description='T-threshold'),
-             figsize=fixed(figsize))
-    return
-
-
-def _iviewer(objIn, x, y, z, stat, figsize):
-    """
-    Generator function for ibrainViewer
-    """
-    _, ax = plt.subplots(1, figsize=figsize)
-    plot_stat_map(objIn.to_nifti(),
-                  display_mode='ortho',
-                  bg_img=resolve_mni_path(MNI_Template)['brain'],
-                  cut_coords=(x, y, z),
-                  threshold=stat,
-                  draw_cross=False,
-                  black_bg=True,
-                  dim=.25,
-                  axes=ax)
-    return
-
-
 def dist_from_hyperplane_plot(stats_output):
     """ Plot SVM Classification Distance from Hyperplane
 

--- a/nltools/stats.py
+++ b/nltools/stats.py
@@ -1357,7 +1357,7 @@ def distance_correlation(x, y, bias_corrected=True, return_all_stats=False):
     return out
 
 
-def procrustes_distance(mat1, mat2, n_permute=5000, tail=1, n_jobs=-1, random_state=None):
+def procrustes_distance(mat1, mat2, n_permute=5000, tail=2, n_jobs=-1, random_state=None):
     """ Use procrustes super-position to perform a similarity test between 2 matrices. Matrices need to match in size on their first dimension only, as the smaller matrix on the second dimension will be padded with zeros. After aligning two matrices using the procrustes transformation, use the computed disparity between them (sum of squared error of elements) as a similarity metric. Shuffle the rows of one of the matrices and recompute the disparity to perform inference (Peres-Neto & Jackson, 2001).
 
     Args:
@@ -1373,7 +1373,7 @@ def procrustes_distance(mat1, mat2, n_permute=5000, tail=1, n_jobs=-1, random_st
 
     """
 
-    raise NotImplementedError("procrustes distance is not currently implemented")
+    #raise NotImplementedError("procrustes distance is not currently implemented")
     if mat1.shape[0] != mat2.shape[0]:
         raise ValueError('Both arrays must match on their first dimension')
 
@@ -1394,7 +1394,7 @@ def procrustes_distance(mat1, mat2, n_permute=5000, tail=1, n_jobs=-1, random_st
     stats = dict()
     stats['similarity'] = sse
 
-    all_p = Parallel(n_jobs=n_jobs)(delayed(procrustes)(random_state.permutation(mat1), mat2) for i in range(n_permute))
+    all_p = Parallel(n_jobs=n_jobs)(delayed(procrust)(random_state.permutation(mat1), mat2) for i in range(n_permute))
     all_p = [1 - x[2] for x in all_p]
 
     stats['p'] = _calc_pvalue(all_p, sse, tail)

--- a/nltools/utils.py
+++ b/nltools/utils.py
@@ -249,5 +249,10 @@ def check_brain_data(data):
     return data
 
 
+def _roi_func(brain, roi, algorithm, cv_dict, **kwargs):
+    '''Brain_Data.predict_multi() helper function'''
+    return brain.apply_mask(roi).predict(algorithm=algorithm, cv_dict=cv_dict, plot=False, **kwargs)
+
+
 class AmbiguityError(Exception):
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@
 	scipy
 	six
 	pynv
-	joblib>=0.11
+	joblib==0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 	nibabel>=2.0.1
 	scikit-learn>=0.19.1
-	nilearn>=0.5.0a
+	nilearn>=0.5.0
 	pandas>=0.20
 	numpy>=1.9
 	seaborn>=0.7.0
@@ -8,4 +8,4 @@
 	scipy
 	six
 	pynv
-	joblib == 0.11
+	joblib>=0.11


### PR DESCRIPTION
1) Now supports multi-class classification. For probability models this returns probability
per class. Non-probability models return one decision function output per class except in the case of two classes. For cross-validation fold weight maps, in multi-class case, a list of 2d weight maps, one per cv fold are returned. In two class case a single 2d weight map is returned, one row per cv fold.
2) new `predict_multi` method that can perform parallelized prediction either (a) over non-overlapping rois given a `Brain_Data` instance containing non-overlapping rois. Output is a list of `Brain_Data.predict()` dictionaries, one for each roi; (b) over searchlights defined by radius and option mask of interest, in which case the output is a single accuracy map. Wraps nilearn `Searchlight`
3) Fixed bug in which indexing a 2d `Brain_Data` object with a non-empty Y attribute would fail if the slice was a single integer. This is because the Y datatype would change to an integer and the `.reset_index` call would fail
4) Fixed potential bug in which some sklearn estimators were not "reset" across cross-validation folds resulting in the same output each fold

Local tests pass. 