### PR TITLE
Hdf5 support for Adjacency class

### DIFF
--- a/nltools/data/adjacency.py
+++ b/nltools/data/adjacency.py
@@ -11,6 +11,7 @@ import os
 import pandas as pd
 import numpy as np
 import six
+import deepdish as dd
 from copy import deepcopy
 from sklearn.metrics.pairwise import pairwise_distances
 from sklearn.manifold import MDS
@@ -32,7 +33,8 @@ from nltools.plotting import (plot_stacked_adjacency,
 from nltools.utils import (all_same,
                            attempt_to_import,
                            concatenate,
-                           _bootstrap_apply_func)
+                           _bootstrap_apply_func,
+                           _df_meta_to_arr)
 from .design_matrix import Design_Matrix
 from joblib import Parallel, delayed
 
@@ -98,6 +100,14 @@ class Adjacency(object):
                 self.issymmetric = symmetric_all[0]
                 self.matrix_type = matrix_type_all[0]
             self.is_single_matrix = False
+        elif isinstance(data, six.string_types) and (('.h5' in data) or ('.hdf5' in data)):
+            f = dd.io.load(data)
+            self.data = f['data']
+            self.Y = pd.DataFrame(f['Y'], columns=[e.decode('utf-8') if isinstance(e, bytes) else e for e in f['Y_columns']], index=[e.decode('utf-8') if isinstance(e, bytes) else e for e in f['Y_index']])
+            self.matrix_type = f['matrix_type']
+            self.is_single_matrix = f['is_single_matrix']
+            self.issymmetric = f['issymmetric']
+            return
         else:
             self.data, self.issymmetric, self.matrix_type, self.is_single_matrix = self._import_single_data(data, matrix_type=matrix_type)
 
@@ -431,28 +441,43 @@ class Adjacency(object):
 
         return out
 
-    def write(self, file_name, method='long'):
+    def write(self, file_name, method='long', **kwargs):
         ''' Write out Adjacency object to csv file.
 
             Args:
                 file_name (str):  name of file name to write
                 method (str):     method to write out data ['long','square']
+                kwargs: optional arguments to deepdish.io.save
 
         '''
         if method not in ['long', 'square']:
             raise ValueError('Make sure method is ["long","square"].')
-        if self.is_single_matrix:
-            if method == 'long':
-                pd.DataFrame(self.data).to_csv(file_name, index=None)
-            elif method == 'square':
-                pd.DataFrame(self.squareform()).to_csv(file_name, index=None)
+
+        if ('.h5' in file_name) or ('.hdf5' in file_name):
+            if method == 'square':
+                raise NotImplementedError('Saving as hdf5 does not support method="square"')            
+            y_columns, y_index = _df_meta_to_arr(self.Y)
+            dd.io.save(file_name, {
+                'data': self.data,
+                'Y': self.Y.values,
+                'Y_columns': y_columns,
+                'Y_index': y_index,
+                'matrix_type': self.matrix_type,
+                'labels': np.array(self.labels, dtype='S'),
+                'is_single_matrix': self.is_single_matrix,
+                'issymmetric': self.issymmetric
+            }, compression=kwargs.get('compression', 'blosc'))
         else:
-            if method == 'long':
-                pd.DataFrame(self.data).to_csv(file_name, index=None)
-            elif method == 'square':
-                raise NotImplementedError('Need to decide how we should write '
-                                          'out multiple matrices.  As separate '
-                                          'files?')
+            if self.is_single_matrix:
+                if method == 'long':
+                    pd.DataFrame(self.data).to_csv(file_name, index=None)
+                elif method == 'square':
+                    pd.DataFrame(self.squareform()).to_csv(file_name, index=None)
+            else:
+                if method == 'long':
+                    pd.DataFrame(self.data).to_csv(file_name, index=None)
+                elif method == 'square':
+                    raise NotImplementedError('Need to decide how we should write out multiple matrices. As separate files?')
 
     def similarity(self, data, plot=False, perm_type='2d', n_permute=5000,
                    metric='spearman', **kwargs):

--- a/nltools/data/adjacency.py
+++ b/nltools/data/adjacency.py
@@ -107,6 +107,7 @@ class Adjacency(object):
             self.matrix_type = f['matrix_type']
             self.is_single_matrix = f['is_single_matrix']
             self.issymmetric = f['issymmetric']
+            self.labels = [e.decode('utf-8') if isinstance(e, bytes) else e for e in f['labels']]
             return
         else:
             self.data, self.issymmetric, self.matrix_type, self.is_single_matrix = self._import_single_data(data, matrix_type=matrix_type)

--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -294,7 +294,7 @@ class Brain_Data(object):
                 raise ValueError("Both Brain_Data() instances need to be the "
                                  "same shape.")
             new.data = np.multiply(new.data, y.data)
-        elif isinstance(y, (list, np.ndarray, np.array)):
+        elif isinstance(y, (list, np.ndarray)):
             if len(y) != len(self):
                 raise ValueError('Vector multiplication requires that the '
                                  'length of the vector match the number of '

--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -427,6 +427,7 @@ class Brain_Data(object):
                              'mni', or 'full'
             threshold_lower: (str/float)threshold if view is 'glass',
                              'mni', or 'full'
+            save: (str/bool): optional string file name or path for saving; only applies if view is 'mni', 'glass', or 'full'. Filenames will appended with the orientation they belong to
 
         """
 

--- a/nltools/plotting.py
+++ b/nltools/plotting.py
@@ -298,7 +298,8 @@ def plot_brain(objIn, how="full", thr_upper=None, thr_lower=None, save=False, **
             plot_abs=False,
             **kwargs
         )
-        plt.savefig(glass_save, bbox_inches="tight")
+        if save:
+            plt.savefig(glass_save, bbox_inches="tight")
         for v, c, savefile in zip(views, coords, saves):
             plot_stat_map(
                 obj.to_nifti(),
@@ -308,7 +309,8 @@ def plot_brain(objIn, how="full", thr_upper=None, thr_lower=None, save=False, **
                 bg_img=resolve_mni_path(MNI_Template)["brain"],
                 **kwargs
             )
-            plt.savefig(savefile, bbox_inches="tight")
+            if save:
+                plt.savefig(savefile, bbox_inches="tight")
     elif how == "glass":
         plot_glass_brain(
             obj.to_nifti(),
@@ -318,7 +320,8 @@ def plot_brain(objIn, how="full", thr_upper=None, thr_lower=None, save=False, **
             plot_abs=False,
             **kwargs
         )
-        plt.savefig(glass_save, bbox_inches="tight")
+        if save:
+            plt.savefig(glass_save, bbox_inches="tight")
     elif how == "mni":
         for v, c in zip(views, coords, saves):
             plot_stat_map(
@@ -329,7 +332,8 @@ def plot_brain(objIn, how="full", thr_upper=None, thr_lower=None, save=False, **
                 bg_img=resolve_mni_path(MNI_Template)["brain"],
                 **kwargs
             )
-            plt.savefig(savefile, bbox_inches="tight")
+            if save:
+                plt.savefig(savefile, bbox_inches="tight")
     del obj  # save memory
     return
 

--- a/nltools/plotting.py
+++ b/nltools/plotting.py
@@ -1,22 +1,24 @@
-'''
+"""
 NeuroLearn Plotting Tools
 =========================
 
 Numerous functions to plot data
 
-'''
+"""
 
-__all__ = ['dist_from_hyperplane_plot',
-           'scatterplot',
-           'probability_plot',
-           'roc_plot',
-           'plot_stacked_adjacency',
-           'plot_mean_label_distance',
-           'plot_between_label_distance',
-           'plot_silhouette',
-           'plot_t_brain',
-           'plot_brain',
-           'plot_interactive_brain']
+__all__ = [
+    "dist_from_hyperplane_plot",
+    "scatterplot",
+    "probability_plot",
+    "roc_plot",
+    "plot_stacked_adjacency",
+    "plot_mean_label_distance",
+    "plot_between_label_distance",
+    "plot_silhouette",
+    "plot_t_brain",
+    "plot_brain",
+    "plot_interactive_brain",
+]
 __author__ = ["Luke Chang"]
 __license__ = "MIT"
 
@@ -29,12 +31,22 @@ from nilearn.plotting import plot_glass_brain, plot_stat_map, view_img, view_img
 from nltools.prefs import MNI_Template, resolve_mni_path
 from nltools.utils import attempt_to_import
 import warnings
+import os
 
 # Optional dependencies
-ipywidgets = attempt_to_import('ipywidgets',name='ipywidgets',fromlist=['interact','fixed','widgets'])
+ipywidgets = attempt_to_import(
+    "ipywidgets", name="ipywidgets", fromlist=["interact", "fixed", "widgets"]
+)
 
 
-def plot_interactive_brain(brain, threshold=1e-6, surface=False, percentile_threshold=False, anatomical=None, **kwargs):
+def plot_interactive_brain(
+    brain,
+    threshold=1e-6,
+    surface=False,
+    percentile_threshold=False,
+    anatomical=None,
+    **kwargs
+):
     """
     This function leverages nilearn's new javascript based brain viewer functions to create interactive plotting functionality.
 
@@ -50,10 +62,12 @@ def plot_interactive_brain(brain, threshold=1e-6, surface=False, percentile_thre
     """
 
     if ipywidgets is None:
-        raise ImportError("ipywidgets>=5.2.2 is required for interactive plotting. Please install this package manually or install nltools with optional arguments: pip install 'nltools[interactive_plots]'")
+        raise ImportError(
+            "ipywidgets>=5.2.2 is required for interactive plotting. Please install this package manually or install nltools with optional arguments: pip install 'nltools[interactive_plots]'"
+        )
 
     if isinstance(threshold, str):
-        if threshold[-1] != '%':
+        if threshold[-1] != "%":
             raise ValueError("Starting threshold provided as string must end in '%'")
         percentile_threshold = True
         threshold = int(threshold[:-1])
@@ -66,21 +80,33 @@ def plot_interactive_brain(brain, threshold=1e-6, surface=False, percentile_thre
     else:
         raise ValueError("Brain_Data object is not 1d or 2d")
 
-    thresh_box = ipywidgets.widgets.FloatText(value=threshold, description='Threshold')
+    thresh_box = ipywidgets.widgets.FloatText(value=threshold, description="Threshold")
 
     if time_slider:
-        idx = ipywidgets.widgets.IntSlider(min=0,
-                                max=max_idx,
-                                step=1,
-                                value=0,
-                                orientation='horizontal',
-                                continuous_update=False,
-                                description='Volume',
-                                readout_format='d'
-                                )
+        idx = ipywidgets.widgets.IntSlider(
+            min=0,
+            max=max_idx,
+            step=1,
+            value=0,
+            orientation="horizontal",
+            continuous_update=False,
+            description="Volume",
+            readout_format="d",
+        )
     else:
-        idx = ipywidgets.widgets.HTML(value="Image is 3D", description="Volume", placeholder="")
-    ipywidgets.interact(_viewer, brain=ipywidgets.fixed(brain), thresh=thresh_box, idx=idx, percentile_threshold=percentile_threshold, surface=surface, anatomical=ipywidgets.fixed(anatomical), **kwargs)
+        idx = ipywidgets.widgets.HTML(
+            value="Image is 3D", description="Volume", placeholder=""
+        )
+    ipywidgets.interact(
+        _viewer,
+        brain=ipywidgets.fixed(brain),
+        thresh=thresh_box,
+        idx=idx,
+        percentile_threshold=percentile_threshold,
+        surface=surface,
+        anatomical=ipywidgets.fixed(anatomical),
+        **kwargs
+    )
 
 
 def _viewer(brain, thresh, idx, percentile_threshold, surface, anatomical, **kwargs):
@@ -88,7 +114,7 @@ def _viewer(brain, thresh, idx, percentile_threshold, surface, anatomical, **kwa
         thresh = 1e-6
     else:
         if percentile_threshold:
-            thresh = str(thresh) + '%'
+            thresh = str(thresh) + "%"
     if isinstance(idx, int):
         b = brain[idx].to_nifti()
     else:
@@ -96,16 +122,20 @@ def _viewer(brain, thresh, idx, percentile_threshold, surface, anatomical, **kwa
     if anatomical:
         bg_img = anatomical
     else:
-        bg_img = 'MNI152'
-    cut_coords = kwargs.get('cut_coords', [0, 0, 0])
+        bg_img = "MNI152"
+    cut_coords = kwargs.get("cut_coords", [0, 0, 0])
 
     if surface:
         return view_img_on_surf(b, threshold=thresh, **kwargs)
     else:
-        return view_img(b, bg_img=bg_img, threshold=thresh, cut_coords=cut_coords, **kwargs)
+        return view_img(
+            b, bg_img=bg_img, threshold=thresh, cut_coords=cut_coords, **kwargs
+        )
 
 
-def plot_t_brain(objIn, how='full', thr='unc', alpha=None, nperm=None, cut_coords=[], **kwargs):
+def plot_t_brain(
+    objIn, how="full", thr="unc", alpha=None, nperm=None, cut_coords=[], **kwargs
+):
     """
     Takes a brain data object and computes a 1 sample t-test across it's first axis. If a list is provided will compute difference between brain data objects in list (i.e. paired samples t-test).
     Args:
@@ -118,38 +148,44 @@ def plot_t_brain(objIn, how='full', thr='unc', alpha=None, nperm=None, cut_coord
         kwargs: optionals args to nilearn plot functions (e.g. vmax)
 
     """
-    if thr not in ['unc', 'fdr', 'tfce']:
+    if thr not in ["unc", "fdr", "tfce"]:
         raise ValueError("Acceptable threshold methods are 'unc','fdr','tfce'")
-    views = ['x', 'y', 'z']
+    views = ["x", "y", "z"]
     if len(cut_coords) == 0:
-        cut_coords = [range(-40, 50, 10), [-88, -72, -58, -38, -26, 8, 20, 34, 46], [-34, -22, -10, 0, 16, 34, 46, 56, 66]]
+        cut_coords = [
+            range(-40, 50, 10),
+            [-88, -72, -58, -38, -26, 8, 20, 34, 46],
+            [-34, -22, -10, 0, 16, 34, 46, 56, 66],
+        ]
     else:
         if len(cut_coords) != 3:
-            raise ValueError('cut_coords must be a list of coordinates like [[xs],[ys],[zs]]')
-    cmap = 'RdBu_r'
+            raise ValueError(
+                "cut_coords must be a list of coordinates like [[xs],[ys],[zs]]"
+            )
+    cmap = "RdBu_r"
 
     if isinstance(objIn, list):
         if len(objIn) == 2:
-            obj = objIn[0]-objIn[1]
+            obj = objIn[0] - objIn[1]
         else:
-            raise ValueError('Contrasts should contain only 2 list items!')
+            raise ValueError("Contrasts should contain only 2 list items!")
 
     thrDict = {}
-    if thr == 'tfce':
-        thrDict['permutation'] = thr
+    if thr == "tfce":
+        thrDict["permutation"] = thr
         if nperm is None:
             nperm = 1000
-        thrDict['n_permutations'] = nperm
+        thrDict["n_permutations"] = nperm
         print("1-sample t-test corrected using: TFCE w/ %s permutations" % nperm)
     else:
-        if thr == 'unc':
+        if thr == "unc":
             if alpha is None:
-                alpha = .001
+                alpha = 0.001
             thrDict[thr] = alpha
             print("1-sample t-test uncorrected at p < %.3f " % alpha)
-        elif thr == 'fdr':
+        elif thr == "fdr":
             if alpha is None:
-                alpha = .05
+                alpha = 0.05
             thrDict[thr] = alpha
             print("1-sample t-test corrected at q < %.3f " % alpha)
         else:
@@ -158,27 +194,53 @@ def plot_t_brain(objIn, how='full', thr='unc', alpha=None, nperm=None, cut_coord
 
     out = objIn.ttest(threshold_dict=thrDict)
     if thrDict is not None:
-        obj = out['thr_t']
+        obj = out["thr_t"]
     else:
-        obj = out['t']
+        obj = out["t"]
 
-    if how == 'full':
-        plot_glass_brain(obj.to_nifti(), display_mode='lzry', colorbar=True, cmap=cmap, plot_abs=False, **kwargs)
+    if how == "full":
+        plot_glass_brain(
+            obj.to_nifti(),
+            display_mode="lzry",
+            colorbar=True,
+            cmap=cmap,
+            plot_abs=False,
+            **kwargs
+        )
         for v, c in zip(views, cut_coords):
-            plot_stat_map(obj.to_nifti(), cut_coords=c, display_mode=v, cmap=cmap, bg_img=resolve_mni_path(MNI_Template)['brain'],
-                          **kwargs)
-    elif how == 'glass':
-        plot_glass_brain(obj.to_nifti(), display_mode='lzry', colorbar=True, cmap=cmap, plot_abs=False, **kwargs)
-    elif how == 'mni':
+            plot_stat_map(
+                obj.to_nifti(),
+                cut_coords=c,
+                display_mode=v,
+                cmap=cmap,
+                bg_img=resolve_mni_path(MNI_Template)["brain"],
+                **kwargs
+            )
+    elif how == "glass":
+        plot_glass_brain(
+            obj.to_nifti(),
+            display_mode="lzry",
+            colorbar=True,
+            cmap=cmap,
+            plot_abs=False,
+            **kwargs
+        )
+    elif how == "mni":
         for v, c in zip(views, cut_coords):
-            plot_stat_map(obj.to_nifti(), cut_coords=c, display_mode=v, cmap=cmap, bg_img=resolve_mni_path(MNI_Template)['brain'],
-                          **kwargs)
+            plot_stat_map(
+                obj.to_nifti(),
+                cut_coords=c,
+                display_mode=v,
+                cmap=cmap,
+                bg_img=resolve_mni_path(MNI_Template)["brain"],
+                **kwargs
+            )
     del obj
     del out
     return
 
 
-def plot_brain(objIn, how='full', thr_upper=None, thr_lower=None, **kwargs):
+def plot_brain(objIn, how="full", thr_upper=None, thr_lower=None, save=False, **kwargs):
     """
     More complete brain plotting of a Brain_Data instance
     Args:
@@ -186,6 +248,7 @@ def plot_brain(objIn, how='full', thr_upper=None, thr_lower=None, **kwargs):
         how: (str) whether to plot a glass brain 'glass', 3 view-multi-slice mni 'mni', or both 'full'
         thr_upper: (str/float) thresholding of image. Can be string for percentage, or float for data units (see Brain_Data.threshold()
         thr_lower: (str/float) thresholding of image. Can be string for percentage, or float for data units (see Brain_Data.threshold()
+        save (str): if a string file name or path is provided plots will be saved into this directory appended with the orientation they belong to
         kwargs: optionals args to nilearn plot functions (e.g. vmax)
 
     """
@@ -194,9 +257,13 @@ def plot_brain(objIn, how='full', thr_upper=None, thr_lower=None, **kwargs):
     else:
         obj = objIn.copy()
 
-    views = ['x', 'y', 'z']
-    coords = [range(-50, 51, 8), range(-80, 50, 10), range(-40, 71, 9)]  # [-88,-72,-58,-38,-26,8,20,34,46]
-    cmap = 'RdBu_r'
+    views = ["x", "y", "z"]
+    coords = [
+        range(-50, 51, 8),
+        range(-80, 50, 10),
+        range(-40, 71, 9),
+    ]  # [-88,-72,-58,-38,-26,8,20,34,46]
+    cmap = "RdBu_r"
 
     if thr_upper is None and thr_lower is None:
         print("Plotting unthresholded image")
@@ -210,19 +277,62 @@ def plot_brain(objIn, how='full', thr_upper=None, thr_lower=None, **kwargs):
         elif isinstance(thr_lower, (float, int)):
             print("Plotting voxels with stat value <= %s" % thr_lower)
 
-    if how == 'full':
-        plot_glass_brain(obj.to_nifti(), display_mode='lzry', colorbar=True, cmap=cmap, plot_abs=False, **kwargs)
-        for v, c in zip(views, coords):
-            plot_stat_map(obj.to_nifti(), cut_coords=c, display_mode=v, cmap=cmap, bg_img=resolve_mni_path(MNI_Template)['brain'],
-                          **kwargs)
-    elif how == 'glass':
-        plot_glass_brain(obj.to_nifti(), display_mode='lzry', colorbar=True, cmap=cmap, plot_abs=False, **kwargs)
-    elif how == 'mni':
-        for v, c in zip(views, coords):
-            plot_stat_map(obj.to_nifti(), cut_coords=c, display_mode=v, cmap=cmap, bg_img=resolve_mni_path(MNI_Template)['brain'],
-                          **kwargs)
+    if save:
+        path, filename = os.path.split(save)
+        filename, extension = filename.split(".")
+        glass_save = os.path.join(path, filename + "_glass." + extension)
+        x_save = os.path.join(path, filename + "_x." + extension)
+        y_save = os.path.join(path, filename + "_y." + extension)
+        z_save = os.path.join(path, filename + "_z." + extension)
+    else:
+        glass_save, x_save, y_save, z_save = None, None, None, None
+
+    saves = [x_save, y_save, z_save]
+
+    if how == "full":
+        plot_glass_brain(
+            obj.to_nifti(),
+            display_mode="lzry",
+            colorbar=True,
+            cmap=cmap,
+            plot_abs=False,
+            **kwargs
+        )
+        plt.savefig(glass_save, bbox_inches="tight")
+        for v, c, savefile in zip(views, coords, saves):
+            plot_stat_map(
+                obj.to_nifti(),
+                cut_coords=c,
+                display_mode=v,
+                cmap=cmap,
+                bg_img=resolve_mni_path(MNI_Template)["brain"],
+                **kwargs
+            )
+            plt.savefig(savefile, bbox_inches="tight")
+    elif how == "glass":
+        plot_glass_brain(
+            obj.to_nifti(),
+            display_mode="lzry",
+            colorbar=True,
+            cmap=cmap,
+            plot_abs=False,
+            **kwargs
+        )
+        plt.savefig(glass_save, bbox_inches="tight")
+    elif how == "mni":
+        for v, c in zip(views, coords, saves):
+            plot_stat_map(
+                obj.to_nifti(),
+                cut_coords=c,
+                display_mode=v,
+                cmap=cmap,
+                bg_img=resolve_mni_path(MNI_Template)["brain"],
+                **kwargs
+            )
+            plt.savefig(savefile, bbox_inches="tight")
     del obj  # save memory
     return
+
 
 def dist_from_hyperplane_plot(stats_output):
     """ Plot SVM Classification Distance from Hyperplane
@@ -236,14 +346,24 @@ def dist_from_hyperplane_plot(stats_output):
     """
 
     if "dist_from_hyperplane_xval" in stats_output.columns:
-        fig = sns.factorplot("subject_id", "dist_from_hyperplane_xval", hue="Y", data=stats_output,
-                             kind='point')
+        fig = sns.factorplot(
+            "subject_id",
+            "dist_from_hyperplane_xval",
+            hue="Y",
+            data=stats_output,
+            kind="point",
+        )
     else:
-        fig = sns.factorplot("subject_id", "dist_from_hyperplane_all", hue="Y", data=stats_output,
-                             kind='point')
-    plt.xlabel('Subject', fontsize=16)
-    plt.ylabel('Distance from Hyperplane', fontsize=16)
-    plt.title('Classification', fontsize=18)
+        fig = sns.factorplot(
+            "subject_id",
+            "dist_from_hyperplane_all",
+            hue="Y",
+            data=stats_output,
+            kind="point",
+        )
+    plt.xlabel("Subject", fontsize=16)
+    plt.ylabel("Distance from Hyperplane", fontsize=16)
+    plt.title("Classification", fontsize=18)
     return fig
 
 
@@ -262,9 +382,9 @@ def scatterplot(stats_output):
         fig = sns.lmplot("Y", "yfit_xval", data=stats_output)
     else:
         fig = sns.lmplot("Y", "yfit_all", data=stats_output)
-    plt.xlabel('Y', fontsize=16)
-    plt.ylabel('Predicted Value', fontsize=16)
-    plt.title('Prediction', fontsize=18)
+    plt.xlabel("Y", fontsize=16)
+    plt.ylabel("Predicted Value", fontsize=16)
+    plt.title("Prediction", fontsize=18)
     return fig
 
 
@@ -282,9 +402,9 @@ def probability_plot(stats_output):
         fig = sns.lmplot("Y", "Probability_xval", data=stats_output, logistic=True)
     else:
         fig = sns.lmplot("Y", "Probability_all", data=stats_output, logistic=True)
-    plt.xlabel('Y', fontsize=16)
-    plt.ylabel('Predicted Probability', fontsize=16)
-    plt.title('Prediction', fontsize=18)
+    plt.xlabel("Y", fontsize=16)
+    plt.ylabel("Predicted Probability", fontsize=16)
+    plt.title("Prediction", fontsize=18)
     return fig
 
     # # and plot the result
@@ -312,16 +432,16 @@ def roc_plot(fpr, tpr):
     """
 
     fig = plt.figure()
-    plt.plot(fpr, tpr, color='red', linewidth=3)
+    plt.plot(fpr, tpr, color="red", linewidth=3)
     # fig = sns.tsplot(tpr,fpr,color='red',linewidth=3)
-    plt.xlabel('(1 - Specificity)', fontsize=16)
-    plt.ylabel('Sensitivity', fontsize=16)
-    plt.title('ROC Plot', fontsize=18)
+    plt.xlabel("(1 - Specificity)", fontsize=16)
+    plt.ylabel("Sensitivity", fontsize=16)
+    plt.title("ROC Plot", fontsize=18)
     return fig
 
 
 def plot_stacked_adjacency(adjacency1, adjacency2, normalize=True, **kwargs):
-    ''' Create stacked adjacency to illustrate similarity.
+    """ Create stacked adjacency to illustrate similarity.
 
     Args:
         matrix1:  Adjacency instance 1
@@ -330,26 +450,35 @@ def plot_stacked_adjacency(adjacency1, adjacency2, normalize=True, **kwargs):
 
     Returns:
         matplotlib figure
-    '''
+    """
     from nltools.data import Adjacency
 
     if not isinstance(adjacency1, Adjacency) or not isinstance(adjacency2, Adjacency):
-        raise ValueError('This function requires Adjacency() instances as input.')
+        raise ValueError("This function requires Adjacency() instances as input.")
 
     upper = np.triu(adjacency2.squareform(), k=1)
     lower = np.tril(adjacency1.squareform(), k=-1)
     if normalize:
-        upper = np.triu((adjacency1-adjacency1.mean()).squareform(), k=1)
-        lower = np.tril((adjacency2-adjacency2.mean()).squareform(), k=-1)
-        upper = upper/np.max(upper)
-        lower = lower/np.max(lower)
-    dist = upper+lower
-    return sns.heatmap(dist, xticklabels=False, yticklabels=False, square=True, **kwargs)
+        upper = np.triu((adjacency1 - adjacency1.mean()).squareform(), k=1)
+        lower = np.tril((adjacency2 - adjacency2.mean()).squareform(), k=-1)
+        upper = upper / np.max(upper)
+        lower = lower / np.max(lower)
+    dist = upper + lower
+    return sns.heatmap(
+        dist, xticklabels=False, yticklabels=False, square=True, **kwargs
+    )
 
 
-def plot_mean_label_distance(distance, labels, ax=None, permutation_test=False,
-                             n_permute=5000, fontsize=18, **kwargs):
-    ''' Create a violin plot indicating within and between label distance.
+def plot_mean_label_distance(
+    distance,
+    labels,
+    ax=None,
+    permutation_test=False,
+    n_permute=5000,
+    fontsize=18,
+    **kwargs
+):
+    """ Create a violin plot indicating within and between label distance.
 
     Args:
         distance:  pandas dataframe of distance
@@ -362,47 +491,65 @@ def plot_mean_label_distance(distance, labels, ax=None, permutation_test=False,
         f: heatmap
         stats: (optional if permutation_test=True) permutation results
 
-    '''
+    """
 
     if not isinstance(distance, pd.DataFrame):
-        raise ValueError('distance must be a pandas dataframe')
+        raise ValueError("distance must be a pandas dataframe")
 
     if distance.shape[0] != distance.shape[1]:
-        raise ValueError('distance must be square.')
+        raise ValueError("distance must be square.")
 
     if len(labels) != distance.shape[0]:
-        raise ValueError('Labels must be same length as distance matrix')
+        raise ValueError("Labels must be same length as distance matrix")
 
-    out = pd.DataFrame(columns=['Distance', 'Group', 'Type'], index=None)
+    out = pd.DataFrame(columns=["Distance", "Group", "Type"], index=None)
     for i in labels.unique():
         tmp_w = pd.DataFrame(columns=out.columns, index=None)
-        tmp_w['Distance'] = distance.loc[labels == i, labels == i].values[np.triu_indices(sum(labels == i), k=1)]
-        tmp_w['Type'] = 'Within'
-        tmp_w['Group'] = i
+        tmp_w["Distance"] = distance.loc[labels == i, labels == i].values[
+            np.triu_indices(sum(labels == i), k=1)
+        ]
+        tmp_w["Type"] = "Within"
+        tmp_w["Group"] = i
         tmp_b = pd.DataFrame(columns=out.columns, index=None)
-        tmp_b['Distance'] = distance.loc[labels == i, labels != i].values.flatten()
-        tmp_b['Type'] = 'Between'
-        tmp_b['Group'] = i
+        tmp_b["Distance"] = distance.loc[labels == i, labels != i].values.flatten()
+        tmp_b["Type"] = "Between"
+        tmp_b["Group"] = i
         out = out.append(tmp_w).append(tmp_b)
-    f = sns.violinplot(x="Group", y="Distance", hue="Type", data=out, split=True, inner='quartile',
-                       palette={"Within": "lightskyblue", "Between": "red"}, ax=ax, **kwargs)
-    f.set_ylabel('Average Distance', fontsize=fontsize)
-    f.set_title('Average Group Distance', fontsize=fontsize)
+    f = sns.violinplot(
+        x="Group",
+        y="Distance",
+        hue="Type",
+        data=out,
+        split=True,
+        inner="quartile",
+        palette={"Within": "lightskyblue", "Between": "red"},
+        ax=ax,
+        **kwargs
+    )
+    f.set_ylabel("Average Distance", fontsize=fontsize)
+    f.set_title("Average Group Distance", fontsize=fontsize)
     if permutation_test:
         stats = dict()
         for i in labels.unique():
             # Between group test
-            tmp1 = out.loc[(out['Group'] == i) & (out['Type'] == 'Within'), 'Distance']
-            tmp2 = out.loc[(out['Group'] == i) & (out['Type'] == 'Between'), 'Distance']
+            tmp1 = out.loc[(out["Group"] == i) & (out["Type"] == "Within"), "Distance"]
+            tmp2 = out.loc[(out["Group"] == i) & (out["Type"] == "Between"), "Distance"]
             stats[str(i)] = two_sample_permutation(tmp1, tmp2, n_permute=n_permute)
         return (f, stats)
     else:
         return f
 
 
-def plot_between_label_distance(distance, labels, ax=None, permutation_test=True,
-                                n_permute=5000, fontsize=18, **kwargs):
-    ''' Create a heatmap indicating average between label distance
+def plot_between_label_distance(
+    distance,
+    labels,
+    ax=None,
+    permutation_test=True,
+    n_permute=5000,
+    fontsize=18,
+    **kwargs
+):
+    """ Create a heatmap indicating average between label distance
 
 
         Args:
@@ -418,27 +565,39 @@ def plot_between_label_distance(distance, labels, ax=None, permutation_test=True
             within_dist_out: average pairwise distance matrix
             mn_dist_out: (optional if permutation_test=True) average difference in distance between conditions
             p_dist_out: (optional if permutation_test=True) p-value for difference in distance between conditions
-    '''
+    """
 
     labels = np.unique(np.array(labels))
 
-    out = pd.DataFrame(columns=['Distance', 'Group', 'Comparison'], index=None)
+    out = pd.DataFrame(columns=["Distance", "Group", "Comparison"], index=None)
     for i in labels:
         for j in labels:
             tmp_b = pd.DataFrame(columns=out.columns, index=None)
-            if distance.loc[labels == i, labels == j].shape[0] == distance.loc[labels == i, labels == j].shape[1]:
-                tmp_b['Distance'] = distance.loc[labels == i, labels == i].values[np.triu_indices(sum(labels == i), k=1)]
+            if (
+                distance.loc[labels == i, labels == j].shape[0]
+                == distance.loc[labels == i, labels == j].shape[1]
+            ):
+                tmp_b["Distance"] = distance.loc[labels == i, labels == i].values[
+                    np.triu_indices(sum(labels == i), k=1)
+                ]
             else:
-                tmp_b['Distance'] = distance.loc[labels == i, labels == j].values.flatten()
-            tmp_b['Comparison'] = j
-            tmp_b['Group'] = i
+                tmp_b["Distance"] = distance.loc[
+                    labels == i, labels == j
+                ].values.flatten()
+            tmp_b["Comparison"] = j
+            tmp_b["Group"] = i
             out = out.append(tmp_b)
 
-    within_dist_out = pd.DataFrame(np.zeros((len(out['Group'].unique()), len(out['Group'].unique()))),
-                                   columns=out['Group'].unique(), index=out['Group'].unique())
-    for i in out['Group'].unique():
-        for j in out['Comparison'].unique():
-            within_dist_out.loc[i, j] = out.loc[(out['Group'] == i) & (out['Comparison'] == j)]['Distance'].mean()
+    within_dist_out = pd.DataFrame(
+        np.zeros((len(out["Group"].unique()), len(out["Group"].unique()))),
+        columns=out["Group"].unique(),
+        index=out["Group"].unique(),
+    )
+    for i in out["Group"].unique():
+        for j in out["Comparison"].unique():
+            within_dist_out.loc[i, j] = out.loc[
+                (out["Group"] == i) & (out["Comparison"] == j)
+            ]["Distance"].mean()
 
     if ax is None:
         f, ax = plt.subplots(1)
@@ -446,28 +605,47 @@ def plot_between_label_distance(distance, labels, ax=None, permutation_test=True
         f = plt.figure()
 
     if permutation_test:
-        mn_dist_out = pd.DataFrame(np.zeros((len(out['Group'].unique()), len(out['Group'].unique()))),
-                                   columns=out['Group'].unique(), index=out['Group'].unique())
-        p_dist_out = pd.DataFrame(np.zeros((len(out['Group'].unique()), len(out['Group'].unique()))),
-                                  columns=out['Group'].unique(), index=out['Group'].unique())
-        for i in out['Group'].unique():
-            for j in out['Comparison'].unique():
-                tmp1 = out.loc[(out['Group'] == i) & (out['Comparison'] == i), 'Distance']
-                tmp2 = out.loc[(out['Group'] == i) & (out['Comparison'] == j), 'Distance']
+        mn_dist_out = pd.DataFrame(
+            np.zeros((len(out["Group"].unique()), len(out["Group"].unique()))),
+            columns=out["Group"].unique(),
+            index=out["Group"].unique(),
+        )
+        p_dist_out = pd.DataFrame(
+            np.zeros((len(out["Group"].unique()), len(out["Group"].unique()))),
+            columns=out["Group"].unique(),
+            index=out["Group"].unique(),
+        )
+        for i in out["Group"].unique():
+            for j in out["Comparison"].unique():
+                tmp1 = out.loc[
+                    (out["Group"] == i) & (out["Comparison"] == i), "Distance"
+                ]
+                tmp2 = out.loc[
+                    (out["Group"] == i) & (out["Comparison"] == j), "Distance"
+                ]
                 s = two_sample_permutation(tmp1, tmp2, n_permute=n_permute)
-                mn_dist_out.loc[i, j] = s['mean']
-                p_dist_out.loc[i, j] = s['p']
+                mn_dist_out.loc[i, j] = s["mean"]
+                p_dist_out.loc[i, j] = s["p"]
         sns.heatmap(mn_dist_out, ax=ax, square=True, **kwargs)
-        sns.heatmap(mn_dist_out, mask=p_dist_out > .05, square=True, linewidth=2, annot=True, ax=ax, cbar=False)
+        sns.heatmap(
+            mn_dist_out,
+            mask=p_dist_out > 0.05,
+            square=True,
+            linewidth=2,
+            annot=True,
+            ax=ax,
+            cbar=False,
+        )
         return (f, out, within_dist_out, mn_dist_out, p_dist_out)
     else:
         f = sns.heatmap(within_dist_out, ax=ax, square=True, **kwargs)
         return (f, out, within_dist_out)
 
 
-def plot_silhouette(distance, labels, ax=None, permutation_test=True,
-                    n_permute=5000, **kwargs):
-    ''' Create a silhouette plot indicating between relative to within label distance
+def plot_silhouette(
+    distance, labels, ax=None, permutation_test=True, n_permute=5000, **kwargs
+):
+    """ Create a silhouette plot indicating between relative to within label distance
 
         Args:
             distance: (pandas dataframe) brain_distance matrix
@@ -484,35 +662,39 @@ def plot_silhouette(distance, labels, ax=None, permutation_test=True,
             # within_dist_out: average pairwise distance matrix
             # mn_dist_out: (optional if permutation_test=True) average difference in distance between conditions
             # p_dist_out: (optional if permutation_test=True) p-value for difference in distance between conditions
-    '''
+    """
 
     # Define label set
     labelSet = np.unique(np.array(labels))
     n_clusters = len(labelSet)
 
     # Set defaults for plot design
-    if 'colors' not in kwargs.keys():
+    if "colors" not in kwargs.keys():
         colors = sns.color_palette("hls", n_clusters)
-    if 'figsize' not in kwargs.keys():
+    if "figsize" not in kwargs.keys():
         figsize = (6, 4)
 
     # Compute silhouette scores
-    out = pd.DataFrame(columns=('Label', 'MeanWit', 'MeanBet', 'Sil'))
+    out = pd.DataFrame(columns=("Label", "MeanWit", "MeanBet", "Sil"))
     for index in range(len(labels)):
         label = labels.iloc[index]
-        sameIndices = [i for i, labelcur in enumerate(labels) if (labelcur == label) & (i != index)]
+        sameIndices = [
+            i for i, labelcur in enumerate(labels) if (labelcur == label) & (i != index)
+        ]
         within = distance.iloc[index, sameIndices].values.flatten()
         otherIndices = [i for i, labelcur in enumerate(labels) if (labelcur != label)]
         between = distance.iloc[index, otherIndices].values.flatten()
-        silhouetteScore = (np.mean(between)-np.mean(within))/max(np.mean(between), np.mean(within))
+        silhouetteScore = (np.mean(between) - np.mean(within)) / max(
+            np.mean(between), np.mean(within)
+        )
         out_tmp = pd.DataFrame(columns=out.columns)
         out_tmp.at[index] = index
-        out_tmp['Label'] = label
-        out_tmp['MeanWit'] = np.mean(within)
-        out_tmp['MeanBet'] = np.mean(between)
-        out_tmp['Sil'] = silhouetteScore
+        out_tmp["Label"] = label
+        out_tmp["MeanWit"] = np.mean(within)
+        out_tmp["MeanBet"] = np.mean(between)
+        out_tmp["Sil"] = silhouetteScore
         out = out.append(out_tmp)
-    sample_silhouette_values = out['Sil']
+    sample_silhouette_values = out["Sil"]
 
     # Plot
     with sns.axes_style("white"):
@@ -531,8 +713,13 @@ def plot_silhouette(distance, labels, ax=None, permutation_test=True,
 
         color = colors[labelInd]
         with sns.axes_style("white"):
-            plt.fill_between(np.arange(x_lower, x_upper), 0, ith_cluster_silhouette_values,
-                             facecolor=color, edgecolor=color)
+            plt.fill_between(
+                np.arange(x_lower, x_upper),
+                0,
+                ith_cluster_silhouette_values,
+                facecolor=color,
+                edgecolor=color,
+            )
 
         labelX = np.hstack((labelX, np.mean([x_lower, x_upper])))
         x_lower = x_upper + 3
@@ -540,24 +727,25 @@ def plot_silhouette(distance, labels, ax=None, permutation_test=True,
     # Format plot
     ax.set_xticks(labelX)
     ax.set_xticklabels(labelSet)
-    ax.set_title('Silhouettes', fontsize=18)
-    ax.set_xlim([5, 10+len(labels)+n_clusters*3])
+    ax.set_title("Silhouettes", fontsize=18)
+    ax.set_xlim([5, 10 + len(labels) + n_clusters * 3])
 
     # Permutation test on mean silhouette score per label
     if permutation_test:
-        outAll = pd.DataFrame(columns=['label', 'mean', 'p'])
+        outAll = pd.DataFrame(columns=["label", "mean", "p"])
         for labelInd in range(n_clusters):
             temp = pd.DataFrame(columns=outAll.columns)
             label = labelSet[labelInd]
             data = sample_silhouette_values[labels == label]
-            temp.loc[labelInd, 'label'] = label
-            temp.loc[labelInd, 'mean'] = np.mean(data)
+            temp.loc[labelInd, "label"] = label
+            temp.loc[labelInd, "mean"] = np.mean(data)
             if np.mean(data) > 0:  # Only test positive mean silhouette scores
                 statsout = one_sample_permutation(data, n_permute=n_permute)
-                temp['p'] = statsout['p']
+                temp["p"] = statsout["p"]
             else:
-                temp['p'] = 999
+                temp["p"] = 999
             outAll = outAll.append(temp)
         return (f, outAll)
     else:
-        return (f)
+        return f
+

--- a/nltools/plotting.py
+++ b/nltools/plotting.py
@@ -323,7 +323,7 @@ def plot_brain(objIn, how="full", thr_upper=None, thr_lower=None, save=False, **
         if save:
             plt.savefig(glass_save, bbox_inches="tight")
     elif how == "mni":
-        for v, c in zip(views, coords, saves):
+        for v, c, savefile in zip(views, coords, saves):
             plot_stat_map(
                 obj.to_nifti(),
                 cut_coords=c,

--- a/nltools/stats.py
+++ b/nltools/stats.py
@@ -618,6 +618,7 @@ def matrix_permutation(data1, data2, n_permute=5000, metric='spearman',
             stats: (dict) dictionary of permutation results ['correlation','p']
     """
     random_state = check_random_state(random_state)
+    seeds = random_state.randint(MAX_INT, size=n_permute)
     sq_data1 = check_square_numpy_matrix(data1)
     sq_data2 = check_square_numpy_matrix(data2)
     data1 = sq_data1[np.triu_indices(sq_data1.shape[0], k=1)]
@@ -628,7 +629,7 @@ def matrix_permutation(data1, data2, n_permute=5000, metric='spearman',
     stats['correlation'] = correlation(data1, data2, metric=metric)[0]
 
     all_p = Parallel(n_jobs=n_jobs)(delayed(_permute_func)(
-                    pd.DataFrame(sq_data1), data2, metric=metric)
+                    pd.DataFrame(sq_data1), data2, metric=metric, random_state=seeds[i])
                     for i in range(n_permute))
     stats['p'] = _calc_pvalue(all_p, stats['correlation'], tail)
     return stats

--- a/nltools/tests/test_adjacency.py
+++ b/nltools/tests/test_adjacency.py
@@ -56,6 +56,17 @@ def test_write_multiple(sim_adjacency_multiple, tmpdir):
                               matrix_type='distance_flat')
     assert np.all(np.isclose(sim_adjacency_multiple.data, dat_multiple2.data))
 
+    # Test i/o for hdf5
+    sim_adjacency_multiple.write(os.path.join(str(tmpdir.join('test_write.h5'))))
+    b = Adjacency(os.path.join(tmpdir.join('test_write.h5')))
+    for k in ['Y', 'matrix_type', 'is_single_matrix', 'issymmetric', 'data']:
+        if k == 'data':
+            assert np.allclose(b.__dict__[k], sim_adjacency_multiple.__dict__[k])
+        elif k == 'Y':
+            assert all(b.__dict__[k].eq(sim_adjacency_multiple.__dict__[k]).values)
+        else:
+            assert b.__dict__[k] == sim_adjacency_multiple.__dict__[k]
+
 
 def test_write_directed(sim_adjacency_directed, tmpdir):
     sim_adjacency_directed.write(os.path.join(str(tmpdir.join('Test.csv'))),

--- a/nltools/utils.py
+++ b/nltools/utils.py
@@ -80,7 +80,7 @@ def get_mni_from_img_resolution(brain, img_type='plot'):
         raise ValueError("img_type must be 'plot' or 'brain' ")
     
     res_array = np.abs(np.diag(brain.nifti_masker.affine_)[:3])
-    voxel_dims = np.unique(res_array)
+    voxel_dims = np.unique(abs(res_array))
     if len(voxel_dims) != 1:
         raise ValueError("Voxels are not isometric and cannot be visualized in standard space")
     else:


### PR DESCRIPTION
The `write` method of `Adjacency` now behaves like the `write` method of `Brain_Data` such that, if a file extension of `.h5` or `.hdf5` is provided, the file is stored using deepdish. 

@ljchang I set this up to raise an error if `method='wide'` because there's basically no reason we'd ever want to store something in wide format using hdf5 and it makes reading the data back in a lot tricker. Instead storing as long format make sense all the time as this becomes a 1d numpy array if we're dealing with a single Adjacency matrix, or a 2d numpy array if we're dealing with multiple. I've left the csv writing functionality as-is. Let me know if you want to do something differently

Includes tests.

Also includes bug fix for https://github.com/cosanlab/nltools/issues/305
