### PR TITLE
Fixed minor bug in Brain_Data.align when using SRM

### DIFF
--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -1839,9 +1839,9 @@ class Brain_Data(object):
             U, _, V = np.linalg.svd(A, full_matrices=False)
 
             out['transformation_matrix'] = source
-            out['transformation_matrix'].data = U.dot(V)
+            out['transformation_matrix'].data = U.dot(V).T
 
-            out['transformed'] = data1.dot(out['transformation_matrix'].data)
+            out['transformed'] = data1.dot(out['transformation_matrix'].data.T)
             out['common_model'] = target
         elif method == 'procrustes':
             _, transformed, out['disparity'], tf_mtx, out['scale'] = procrustes(data2, data1)

--- a/nltools/tests/test_brain_data.py
+++ b/nltools/tests/test_brain_data.py
@@ -479,7 +479,7 @@ def test_hyperalignment():
     assert d1.shape() == bout['transformed'].shape
     assert d1.shape() == bout['common_model'].shape
     assert d1.shape()[1] == bout['transformation_matrix'].shape()[0]
-    btransformed = np.dot(d1.data, bout['transformation_matrix'].data)
+    btransformed = np.dot(d1.data, bout['transformation_matrix'].data.T)
     np.testing.assert_almost_equal(0, np.sum(bout['transformed'].data - btransformed))
 
     # Test probabilistic brain_data
@@ -487,7 +487,7 @@ def test_hyperalignment():
     assert d1.shape() == bout['transformed'].shape
     assert d1.shape() == bout['common_model'].shape
     assert d1.shape()[1] == bout['transformation_matrix'].shape()[0]
-    btransformed = np.dot(d1.data, bout['transformation_matrix'].data)
+    btransformed = np.dot(d1.data, bout['transformation_matrix'].data.T)
     np.testing.assert_almost_equal(0, np.sum(bout['transformed'].data-btransformed))
 
     # Test procrustes brain_data
@@ -520,7 +520,7 @@ def test_hyperalignment():
     assert d1.shape() == bout['transformed'].shape
     assert d1.shape() == bout['common_model'].shape
     assert d1.shape()[0] == bout['transformation_matrix'].shape()[0]
-    btransformed = np.dot(d1.data.T, bout['transformation_matrix'].data)
+    btransformed = np.dot(d1.data.T, bout['transformation_matrix'].data.T)
     np.testing.assert_almost_equal(0, np.sum(bout['transformed'].data-btransformed.T))
 
     out = align(data, method='probabilistic_srm', axis=1)
@@ -528,7 +528,7 @@ def test_hyperalignment():
     assert d1.shape() == bout['transformed'].shape
     assert d1.shape() == bout['common_model'].shape
     assert d1.shape()[0] == bout['transformation_matrix'].shape()[0]
-    btransformed = np.dot(d1.data.T, bout['transformation_matrix'].data)
+    btransformed = np.dot(d1.data.T, bout['transformation_matrix'].data.T)
     np.testing.assert_almost_equal(0, np.sum(bout['transformed'].data-btransformed.T))
 
     out = align(data, method='procrustes', axis=1)


### PR DESCRIPTION
Issue was specific when aligning an SRM to common space. There was a missing transpose, which was resulting in the wrong shape of the transformation matrix Brain_Data object.