### PR TITLE
pin minimum python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author = 'Cosan Lab',
     author_email = 'luke.j.chang@dartmouth.edu',
     url = 'http://neurolearn.readthedocs.org/en/latest/',
+    python_requires = '>=3.6',
     install_requires = requirements,
     extras_require = {
     'interactive_plots':['ipywidgets>=5.2.2']
@@ -32,8 +33,9 @@ setup(
                      'analysis engine powering www.neuro-learn.org.',
     keywords = ['neuroimaging', 'preprocessing', 'analysis','machine-learning'],
     classifiers = [
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
Added `python_requires` field with a min version of 3.6.  At least one pinned dependency version has dropped support for `python<3.6` (#361), and it looks like the travis tests for 2.7 were removed in April 2019.  Also updated the PyPI classifiers to reflect the versions officially supported.  

One test in one job failed on my fork (I think because `SimulateGrid._create_noise()` managed to add more noise than the test will accept?) but it looks like that's been happening on master too.