### PR TITLE
Stop ignoring mask argument when loading h5 brain data file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-    "editor.formatOnSave": true,
+    "[python]": {
+        "editor.formatOnSave": true
+    },
     "python.testing.pytestEnabled": true,
     "python.testing.unittestEnabled": false,
     "python.testing.nosetestsEnabled": false,

--- a/nltools/data/brain_data.py
+++ b/nltools/data/brain_data.py
@@ -169,6 +169,10 @@ class Brain_Data(object):
                             warnings.warn(
                                 "Existing mask found in HDF5 file but is being ignored because you passed a value for mask. Set mask=None to use existing mask in the HDF5 file"
                             )
+                    # We're done initializing from the h5 file so just return no need to
+                    # run any of the additional checks and code below. We should really
+                    # refactor this entire init...
+                    return
                 else:
                     data = nib.load(data)
                 self.data = self.nifti_masker.fit_transform(data)

--- a/nltools/tests/test_brain_data.py
+++ b/nltools/tests/test_brain_data.py
@@ -52,7 +52,7 @@ def test_load(tmpdir):
     # Test i/o for hdf5
     dat.write(os.path.join(str(tmpdir.join("test_write.h5"))))
     b = Brain_Data(os.path.join(tmpdir.join("test_write.h5")))
-    for k in ["X", "Y", "mask", "nifti_masker", "file_name", "data"]:
+    for k in ["X", "Y", "mask", "nifti_masker", "data"]:
         if k == "data":
             assert np.allclose(b.__dict__[k], dat.__dict__[k])
         elif k in ["X", "Y"]:

--- a/nltools/tests/test_brain_data.py
+++ b/nltools/tests/test_brain_data.py
@@ -9,7 +9,7 @@ from nltools.stats import threshold, align
 from nltools.mask import create_sphere, roi_to_brain
 from pathlib import Path
 
-# from nltools.prefs import MNI_Template
+from nltools.prefs import MNI_Template
 
 
 shape_3d = (91, 109, 91)
@@ -68,6 +68,14 @@ def test_load(tmpdir):
             )
         else:
             assert b.__dict__[k] == dat.__dict__[k]
+    # Test situation where we present a user warning when they're trying to load an .h5
+    # file that includes a mask AND they pass in value for the mask argument. In this
+    # case the mask argument takes precedence so we warn the user
+    with pytest.warns(UserWarning):
+        bb = Brain_Data(
+            os.path.join(tmpdir.join("test_write.h5")), mask=MNI_Template["mask"]
+        )
+        assert bb.mask.get_filename() == MNI_Template["mask"]
 
 
 def test_shape(sim_brain_data):


### PR DESCRIPTION
Because h5 files are essentially `Brain_Data` objects, they save data along with a mask to disk. This differs from nifti files which don't contain a mask, just the imaging data.

Previously when loading an h5 file, the `mask=` argument in `Brain_Data` was entirely ignored regardless of whether the user tried to use it or not. We assumed instead that the h5 file contains a mask and we should load that instead.

This produced some situations that @TiankangXie encountered where data were in the correct space (e.g. 3mm), but the `.mask` attribute pointed to the default 2mm mask. As a result `.to_nifti()` throws an error because it tries to apply the wrong transformation to the data when converting.

Because we were ignoring the `mask` when loading h5 files, there was no easy fix to get out of this situation. So, this PR makes `Brain_Data` respect the `mask` argument when loading h5 files. Specifically it defaults to any mask contained within the h5 file when loaded (if there isn't one we let deepdish kick the error). When the user passes a `mask` argument, it will instead use that mask to learn the transformation similar to the behavior of `mask` when loading a nifti file. If we detect that there _already_ exists a mask in the h5 file (which should almost always be true) when the user passes in a `mask`, then we issue a warning telling them we're ignoring the mask in the h5 on load. 

Scenarios and behavior:

```
# User loads h5 that contains mask so that mask is used instead of the default MNI mask

Brain_Data('brain.h5')

# User loads h5 that contains mask but also sets mask argument.
# Now mask value takes precedence over whatever mask is in h5 
# so we issue a warning to the user letting them know on load

Brain_Data('brain.h5', mask='path/to/nifti/mask.nii.gz')

>>> UserWarning(...)

# User loads h5 that does NOT contain a mask and doesnt set the mask
# argument so the default MNI mask is used, similar to nifti files
# This is an implicit fallback just like with niftis 

Brain_Data('brain_nomask.h5')

# User loads h5 that does NOT contain mask but also sets mask argument
# Mask value is used to learn transformation like niftis
# No need to warn them about anything

Brain_Data('brain_nomask.h5', mask='path/to/nifti/mask.nii.gz')
```

@ljchang Can you take a quick look if this makes sense to you and I'm not missing other cases or expected behavior? 

Also removed the `file_name` argument and attribute on `Brain_Data` we weren't using it anywhere except as a default fallback argument to `.write()` if the user didn't pass anything in (which they always should). It was causing problems with h5 files if that attribute didn't exist