### PR TITLE
added isc group functionality

### DIFF
--- a/nltools/stats.py
+++ b/nltools/stats.py
@@ -1887,7 +1887,7 @@ def _compute_isc(data, metric="median"):
 
 def isc(
     data,
-    n_bootstraps=5000,
+    n_samples=5000,
     metric="median",
     method="bootstrap",
     ci_percentile=95,
@@ -1928,7 +1928,7 @@ def isc(
 
     Args:
         data: (pd.DataFrame, np.array) observations by subjects where isc is computed across subjects
-        n_bootstraps: (int) number of bootstraps
+        n_samples: (int) number of random samples/bootstraps
         metric: (str) type of isc summary metric ['mean','median']
         method: (str) method to compute p-values ['bootstrap', 'circle_shift','phase_randomize'] (default: bootstrap)
         tail: (int) either 1 for one-tail or 2 for two-tailed test (default: 2)
@@ -1964,7 +1964,7 @@ def isc(
                 exclude_self_corr=exclude_self_corr,
                 random_state=random_state,
             )
-            for _ in range(n_bootstraps)
+            for _ in range(n_samples)
         )
         stats["p"] = _calc_pvalue(all_bootstraps - stats["isc"], stats["isc"], tail)
 
@@ -1973,7 +1973,7 @@ def isc(
             delayed(_compute_isc)(
                 circle_shift(data, random_state=random_state), metric=metric
             )
-            for _ in range(n_bootstraps)
+            for _ in range(n_samples)
         )
         stats["p"] = _calc_pvalue(all_bootstraps, stats["isc"], tail)
     elif method == "phase_randomize":
@@ -1981,7 +1981,7 @@ def isc(
             delayed(_compute_isc)(
                 phase_randomize(data, random_state=random_state), metric=metric
             )
-            for _ in range(n_bootstraps)
+            for _ in range(n_samples)
         )
         stats["p"] = _calc_pvalue(all_bootstraps, stats["isc"], tail)
     else:

--- a/nltools/stats.py
+++ b/nltools/stats.py
@@ -38,7 +38,8 @@ __all__ = [
     "u_center",
     "_bootstrap_isc",
     "isc",
-    "isc_group" "isfc",
+    "isc_group",
+    "isfc",
     "isps",
     "_compute_matrix_correlation",
     "_phase_mean_angle",
@@ -2083,7 +2084,7 @@ def _permute_isc_group(similarity_matrix, group, metric="median", random_state=N
     if not isinstance(group, np.ndarray):
         raise ValueError("group must be a numpy array.")
 
-    if len(group) != similarity.square_shape()[0]:
+    if len(group) != similarity_matrix.square_shape()[0]:
         raise ValueError(
             "Group array must be the same length as the similarity matrix."
         )

--- a/nltools/tests/test_adjacency.py
+++ b/nltools/tests/test_adjacency.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pandas as pd
 from nltools.data import Adjacency, Design_Matrix
+from nltools.stats import isc_group
 import networkx as nx
 from scipy.stats import pearsonr
 from scipy.linalg import block_diag
@@ -362,7 +363,7 @@ def test_isc(sim_adjacency_single):
     n_boot = 100
     for metric in ["median", "mean"]:
         stats = sim_adjacency_single.isc(
-            metric=metric, n_bootstraps=n_boot, return_bootstraps=True
+            metric=metric, n_samples=n_boot, return_null=True
         )
         assert (stats["isc"] > -1) & (stats["isc"] < 1)
         assert (stats["p"] > 0) & (stats["p"] < 1)

--- a/nltools/tests/test_adjacency.py
+++ b/nltools/tests/test_adjacency.py
@@ -6,6 +6,7 @@ import networkx as nx
 from scipy.stats import pearsonr
 from scipy.linalg import block_diag
 from pathlib import Path
+from sklearn.metrics import pairwise_distances
 
 
 def test_type_single(sim_adjacency_single):
@@ -366,6 +367,48 @@ def test_isc(sim_adjacency_single):
         assert (stats["isc"] > -1) & (stats["isc"] < 1)
         assert (stats["p"] > 0) & (stats["p"] < 1)
         assert len(stats["null_distribution"]) == n_boot
+
+
+def test_isc_group():
+    n_samples = 100
+    diff = 0.2
+    data = np.random.multivariate_normal(
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [
+            [1, 0.2, 0.5, 0.7, 0.3, 0, 0, 0, 0, 0],
+            [0.2, 1, 0.6, 0.1, 0.2, 0, 0, 0, 0, 0],
+            [0.5, 0.6, 1, 0.3, 0.1, 0, 0, 0, 0, 0],
+            [0.7, 0.1, 0.3, 1, 0.4, 0, 0, 0, 0, 0],
+            [0.3, 0.2, 0.1, 0.4, 1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 1, 0.2 + diff, 0.5 + diff, 0.7 + diff, 0.3 + diff],
+            [0, 0, 0, 0, 0, 0.2 + diff, 1, 0.6 + diff, 0.1 + diff, 0.2 + diff],
+            [0, 0, 0, 0, 0, 0.5 + diff, 0.6 + diff, 1, 0.3 + diff, 0.1 + diff],
+            [0, 0, 0, 0, 0, 0.7 + diff, 0.1 + diff, 0.3 + diff, 1, 0.4 + diff],
+            [0, 0, 0, 0, 0, 0.3 + diff, 0.2 + diff, 0.1 + diff, 0.4 + diff, 1],
+        ],
+        500,
+    )
+
+    group = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+
+    similarity = Adjacency(
+        1 - pairwise_distances(data.T, metric="correlation"), matrix_type="similarity"
+    )
+
+    for method in ["permute", "bootstrap"]:
+        for metric in ["median", "mean"]:
+            stats = similarity.isc_group(
+                group,
+                metric=metric,
+                method=method,
+                return_null=True,
+                n_samples=n_samples,
+            )
+            np.testing.assert_almost_equal(
+                stats["isc_group_difference"], diff, decimal=0
+            )
+            assert (stats["p"] > 0) & (stats["p"] < 1)
+            assert len(stats["null_distribution"]) == n_samples
 
 
 def test_fisher_r_to_z(sim_adjacency_single):

--- a/nltools/tests/test_stats.py
+++ b/nltools/tests/test_stats.py
@@ -477,7 +477,7 @@ def test_isc():
                 dat,
                 method=method,
                 metric=metric,
-                n_bootstraps=n_boot,
+                n_samples=n_boot,
                 return_null=True,
             )
             assert stats["isc"] > 0.1

--- a/nltools/tests/test_stats.py
+++ b/nltools/tests/test_stats.py
@@ -506,9 +506,8 @@ def test_isc_group():
         500,
     )
 
-    group = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
-
-    data_similarity = 1 - pairwise_distances(data.T, metric="correlation")
+    group1 = data[:, :5]
+    group2 = data[:, 5:]
 
     for method in ["permute", "bootstrap"]:
         for metric in ["median", "mean"]:


### PR DESCRIPTION
I added a new isc function for computing group differences. 

It has two methods implemented as discussed in:

Chen, G., Shin, Y. W., Taylor, P. A., Glen, D. R., Reynolds, R. C., Israel, R. B.,
    & Cox, R. W. (2016). Untangling the relatedness among correlations, part I:
    nonparametric approaches to inter-subject correlation analysis at the group level.
    NeuroImage, 142, 248-259.

Default is the subject-wise permutation method, where the group labels are permuted on the full group similarity matrix. We also include the subject-wise bootstrap method, which randomly samples participants with replacement for each group and generates a null distribution based on the differences. Chen et al., find that the permutation method works the best for controlling false positive rate and bootstrap method generally works, but can be more conservative in smaller group sizes.

There are few more small changes to other ISC functions:
1. I changed the keyword to `n_samples` from `n_bootstraps` to be more consistent and accurate
2. I changed the keyword to `return_null` from `return_bootstraps` to also be more consistent and accurate
3. I fixed a small bug in the `matrix_permutation` function which was using random sampling instead of permuting. This is unlikely to have affected anything, but will be more accurate.