### PR TITLE
move away from numpy.fix in favor of numpy.trunc

### DIFF
--- a/nltools/stats.py
+++ b/nltools/stats.py
@@ -821,7 +821,7 @@ def make_cosine_basis(nsamples, sampling_freq, filter_length, unit_scale=True, d
     """
 
     # Figure out number of basis functions to create
-    order = int(np.fix(2 * (nsamples * sampling_freq) / filter_length + 1))
+    order = int(np.trunc(2 * (nsamples * sampling_freq) / filter_length + 1))
 
     n = np.arange(nsamples)
 


### PR DESCRIPTION
This PR replaces all occurrences of `numpy.fix` with `numpy.trunc`. This is in response to [a currently discussed deprecation of `numpy.fix`](https://mail.python.org/archives/list/numpy-discussion@python.org/thread/LYRHETXPN32S7FNHKNLJFDIYWGQHLODJ/) as well as performance considerations (nice, but secondary).

This change should not change anything in a meaningful way, internally or externally.

Cheers