### PR TITLE
fix(deps): make h5py a core dependency; BrainCollection.fit() requires it

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -21,7 +21,7 @@ Version 0.6.0 is a **breaking release** that refactors nltools to better leverag
 | **Properties** | Method-style shape/empty checks | `.shape`, `.is_empty` | Changed |
 | **Cross-validation** | N/A | `.fit(..., cv=5)` | New |
 | **HyperAlignment** | Via `align()` only | `HyperAlignment` class | New |
-| **Multi-subject** | `Brain_Collection` | `BrainCollection` redesign | **Not yet available (scaffold)** |
+| **Multi-subject** | `Brain_Collection` | `BrainCollection` — lazy, parallel, disk-cached collection of `(BrainData, DesignMatrix)` pairs with `from_bids` / `from_glob` / `from_paths` constructors and a single `.fit()` | **Rewritten** |
 | **SRM** | N/A | `SRM` / `DetSRM` classes | **New** |
 | **GPU inference** | N/A | `inference` module | **New** |
 | **Algorithm kwarg** | `algorithm=`, `scheme=`, `kind=`, `noise_model=`, `extract_type=`, `mode=`, `perm_type=` | `method=` (or `spatial_scale=` for spatial scale; `Adjacency.similarity` keeps the correlation type in the separate `metric=` slot) | **Renamed** |
@@ -670,7 +670,7 @@ adj.threshold(upper='90%')     # Keep top 10% (percentile threshold)
 
 | Class | Status | Alternative |
 |-------|--------|-------------|
-| `Brain_Collection` | Removed | `BrainCollection` is being redesigned and is currently an unavailable scaffold |
+| `Brain_Collection` | Replaced | `BrainCollection` — see [BrainCollection](#braincollection) |
 | `Model` | Removed | Will return in v0.7.0+ |
 
 ### 3. Attributes
@@ -1609,7 +1609,47 @@ alpha_scores = brain_data.cv_results_['alpha_scores']
 
 ### BrainCollection
 
-`BrainCollection` is being redesigned for v0.6.0 as a parallel/lazy iterator of `BrainData` with a single `.fit()`, first-class `(BrainData, DesignMatrix)` pairing, and disk-cached parallel operations. It is **not yet available** in this release—the class is currently a scaffold. Migration guidance will be added once the facade lands. See `nltools/data/collection/SPEC.md`.
+`BrainCollection` replaces v0.5.1's `Brain_Collection`: a lazy, parallel,
+disk-cached collection of `(BrainData, DesignMatrix)` pairs with a single
+`.fit()`. It is **available in v0.6.0**.
+
+```python
+from nltools.data import BrainCollection, DesignMatrix
+
+bc = BrainCollection.from_paths(bold_paths, mask=mask, design_paths=events_paths,
+                                metadata=subject_table)
+
+# Per-subject first-level GLM, run in parallel and cached to disk.
+fitted = bc.smooth(6).fit(
+    model="glm",
+    X=lambda ctx: DesignMatrix(ctx.dm, run_length=len(ctx.bd), TR=ctx.TR)
+                  .add_poly(order=1, include_lower=True),
+)
+
+# Contrast per subject, then group inference over the stack.
+con = fitted.compute_contrasts("face_c0 - house_c0", statistic="beta")
+con.ttest()                              # {'mean', 't', 'z', 'p'}
+con.permutation_test(n_permute=5000)     # {'mean', 'p'}
+con.predict(y=labels, cv="loso", spatial_scale="roi", roi_mask=atlas)
+```
+
+Constructors: `from_bids`, `from_glob`, `from_paths`. Also available:
+`align`, `anova`, `isc`, `cv`, `map`, `apply`, `detrend`, `filter`,
+`standardize`, `resample`, `threshold`, `write`.
+
+Two contracts worth knowing:
+
+- **The `X=` callable receives a `_DesignContext`, not a `DesignMatrix`.** It
+  exposes `bd`, `dm`, `confounds`, `sample_mask`, `metadata`, `subject`,
+  `session`, `run`, `task`, `TR`, `bold_path`, `events_path`,
+  `confounds_path`, and `__getitem__` falls through to the metadata row.
+- **`from_paths(design_paths=...)` passes paths through unparsed.**
+  `DesignMatrix` has no `read()` classmethod yet, so `ctx.dm` is the path and
+  the builder is responsible for constructing the `DesignMatrix` (as above).
+  `from_bids` materializes designs for you.
+
+See `docs/development/execution-model.md` for the caching model, the `cache=`
+knob, and parallel write safety.
 
 ### Niimg-like inputs in analysis functions
 

--- a/nltools/tests/support/test_packaging.py
+++ b/nltools/tests/support/test_packaging.py
@@ -1,0 +1,82 @@
+"""Packaging invariants.
+
+These guard against a dependency being *used* unconditionally while only being
+*declared* in an optional extra — a failure mode that is invisible in the dev
+environment (which installs every extra) and only surfaces for end users.
+"""
+
+import ast
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# Modules imported unconditionally by the BrainCollection execution path.
+# BrainCollection.fit() always writes HDF5 fit bundles, so these are required
+# for core functionality, not optional add-ons.
+COLLECTION_EXECUTION = Path("nltools/data/collection/execution.py")
+DISTRIBUTION_FOR_MODULE = {"h5py": "h5py", "hdf5plugin": "hdf5plugin"}
+
+
+def _core_dependency_names() -> set[str]:
+    if not PYPROJECT.exists():  # installed-package test run, no source tree
+        pytest.skip("pyproject.toml not available (not a source checkout)")
+    with PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+    names = set()
+    for spec in data["project"]["dependencies"]:
+        # "h5py>=3.15" -> "h5py"; "nltools[h5]" -> "nltools"
+        name = spec.split(";")[0].strip()
+        for sep in ("[", ">", "<", "=", "!", "~", " "):
+            name = name.split(sep)[0]
+        names.add(name.strip().lower().replace("_", "-"))
+    return names
+
+
+def _unguarded_imports(path: Path) -> set[str]:
+    """Top-level module names imported outside any try/except ImportError."""
+    tree = ast.parse(path.read_text())
+    guarded = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for child in ast.walk(node):
+                if isinstance(child, ast.Import):
+                    guarded.update(a.name.split(".")[0] for a in child.names)
+                elif isinstance(child, ast.ImportFrom) and child.module:
+                    guarded.add(child.module.split(".")[0])
+    found = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            found.add(node.module.split(".")[0])
+    return found - guarded
+
+
+def test_collection_execution_imports_are_core_dependencies():
+    """BrainCollection.fit() cannot work without these, so they must be core.
+
+    Regression guard: h5py/hdf5plugin previously lived only in the optional
+    ``h5`` extra, so ``BrainCollection.fit()`` raised ``ModuleNotFoundError``
+    from inside a joblib worker for anyone who installed plain ``nltools``.
+    """
+    path = REPO_ROOT / COLLECTION_EXECUTION
+    if not path.exists():
+        pytest.skip(f"{COLLECTION_EXECUTION} not present")
+
+    core = _core_dependency_names()
+    unguarded = _unguarded_imports(path)
+
+    missing = {
+        dist
+        for module, dist in DISTRIBUTION_FOR_MODULE.items()
+        if module in unguarded and dist.lower() not in core
+    }
+    assert not missing, (
+        f"{COLLECTION_EXECUTION} imports {sorted(missing)} unconditionally, but "
+        f"they are not in [project].dependencies. Either declare them as core "
+        f"dependencies or guard the import with a message pointing at the extra."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ classifiers = [
 keywords=["neuroimaging", "preprocessing", "analysis", "machine-learning"]
 dependencies = [
     "anywidget>=0.9",
+    # BrainCollection.fit() always writes HDF5 fit bundles
+    # (data/collection/execution.py imports h5py unguarded), so h5py is
+    # required for core functionality, not an optional add-on. hdf5plugin
+    # stays in the `h5` extra: it only registers blosc/zstd/lz4 filters for
+    # reading compressed legacy files, and nltools/io/h5.py already guards
+    # that import with an actionable error.
+    "h5py>=3.15",
     "huggingface-hub>=0.30",
     "joblib>=1.5.3",
     "nilearn>=0.12",
@@ -30,6 +37,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# h5py is a core dependency (see above); kept listed here so `nltools[h5]`
+# keeps resolving for anyone who already pins it.
 h5 = ["h5py>=3.15", "hdf5plugin>=6.0.0"]
 graph = ["networkx>=3.5"]
 interactive_plots = ["ipywidgets>=8.1.7"]

--- a/uv.lock
+++ b/uv.lock
@@ -2064,6 +2064,7 @@ version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
+    { name = "h5py" },
     { name = "huggingface-hub" },
     { name = "joblib" },
     { name = "nilearn" },
@@ -2119,6 +2120,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9" },
+    { name = "h5py", specifier = ">=3.15" },
     { name = "h5py", marker = "extra == 'h5'", specifier = ">=3.15" },
     { name = "hdf5plugin", marker = "extra == 'h5'", specifier = ">=6.0.0" },
     { name = "huggingface-hub", specifier = ">=0.30" },


### PR DESCRIPTION
## Problem

`BrainCollection.fit()` always writes an HDF5 fit bundle, and
`nltools/data/collection/execution.py` imports `h5py` unguarded:

```python
def _write_bundle(...):
    import h5py                      # no try/except, no extras check
    with h5py.File(tmp, "w", locking=False) as f:
```

But `h5py` was declared only in the optional `h5` extra. Installing plain
`nltools` and calling `BrainCollection.fit()` fails with:

```
nltools.data.collection.execution.BrainCollectionWorkerError:
  [idx=4] ModuleNotFoundError: No module named 'h5py'
```

Because it is raised inside a joblib worker, the traceback is ~20 frames of
`joblib/parallel.py` before the real cause, which makes it hard to diagnose —
especially for students, which is how I found it (porting the
[dartbrains](https://github.com/ljchang/dartbrains) course to 0.6).

Two things hid this:

- The `dev` dependency group installs `h5py`, so it never reproduces in development.
- `nltools/io/h5.py` *does* guard its import and raise an actionable error, but
  only for the `BrainData` `.h5` path. The collection path never goes through it.

## Fix

Move `h5py` to `[project].dependencies`. `BrainCollection` is a headline v0.6
feature and is unusable without it, so it is not an optional add-on.

`hdf5plugin` deliberately stays in the `h5` extra: it only registers
blosc/zstd/lz4 filters for reading compressed legacy files, the bundle writer
uses no compression filters, and `nltools/io/h5.py` already guards it. The
`h5` extra keeps listing both so existing `nltools[h5]` pins resolve unchanged.

## Regression guard

Adds `nltools/tests/support/test_packaging.py`, which parses `pyproject.toml`
and asserts that modules imported unconditionally by the collection execution
path are declared as core dependencies. Written red-first — it fails on
`master` with:

```
AssertionError: nltools/data/collection/execution.py imports ['h5py']
unconditionally, but they are not in [project].dependencies.
```

The check walks the AST and ignores imports inside `try`/`except`, so guarding
an import (with a friendly message) is still a valid way to satisfy it.

## Docs

The migration guide still described `BrainCollection` as **"not yet available
(scaffold)"** in three places and pointed at `nltools/data/collection/SPEC.md`,
deleted in 378c0c15. The class is fully functional — I verified
`from_paths` → `.smooth().fit(model='glm', X=...)` → `.compute_contrasts()` →
`.ttest()` / `.permutation_test()` / `.predict(spatial_scale=...)` end to end.

Replaced with a worked example plus the two contracts that aren't obvious from
the signatures:

- the `X=` callable receives a `_DesignContext`, not a `DesignMatrix`
- `from_paths(design_paths=...)` passes paths through unparsed, so the builder
  must construct the `DesignMatrix` (matching the source comment: *"DesignMatrix
  has no read() classmethod yet"*)

## Testing

- `uv run poe lint` — clean
- `nltools/tests/support/` — 177 passed
- `nltools/tests/data/collection` — 276 passed

(Both suites need `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` on my machine; a stale local
HF token 401s against the public `nltools/niftis` dataset. Unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVDnsKutg6Yqv99dYmUeuP