### PR TITLE
fix(designmatrix): add_poly() rejects designs with ordinary 2-underscore confounds

### DIFF
--- a/nltools/data/designmatrix/regressors.py
+++ b/nltools/data/designmatrix/regressors.py
@@ -19,9 +19,11 @@ if TYPE_CHECKING:
     from . import DesignMatrix
 
 
-# Columns produced by `append(axis=0, keep_separate=True)` for per-run
-# polynomials, e.g. "0_poly_0", "12_poly_3".
-_RUN_SEPARATED_POLY = re.compile(r"\d+_poly_\d+")
+# Columns produced by `append(axis=0, keep_separate=True)` for per-run drift
+# terms, e.g. "0_poly_0", "12_poly_3", "0_cosine_0". Both `add_poly` and
+# `add_dct_basis` refuse to add a global drift term when either kind is
+# present, since it is ambiguous whether the new term should be per-run.
+_RUN_SEPARATED_DRIFT = re.compile(r"\d+_(?:poly|cosine)_\d+")
 
 
 def convolve(
@@ -187,11 +189,12 @@ def add_poly(
     # Check for ambiguous polynomials from previous append operations.
     # `append(axis=0, keep_separate=True)` prefixes per-run columns with the run
     # index, so run-separated polynomials are named "<run>_poly_<order>" (e.g.
-    # "0_poly_1"). Match that shape exactly: testing `name.count("_") == 2`
-    # instead would also fire on ordinary confounds such as the standard
-    # 24-parameter motion expansion ("trans_x_sq", "rot_x_diff"), blocking
-    # add_poly on single-run designs that have no run-separated polys at all.
-    if dm.confounds and any(_RUN_SEPARATED_POLY.fullmatch(c) for c in dm.confounds):
+    # "0_poly_1", "0_cosine_0"). Match that shape exactly: testing
+    # `name.count("_") == 2` instead would also fire on ordinary confounds such
+    # as the standard 24-parameter motion expansion ("trans_x_sq",
+    # "rot_x_diff"), blocking add_poly on single-run designs that have no
+    # run-separated drift terms at all.
+    if dm.confounds and any(_RUN_SEPARATED_DRIFT.fullmatch(c) for c in dm.confounds):
         raise ValueError(
             "This Design Matrix contains polynomial terms that were kept "
             "separate from a previous append operation. This makes it ambiguous "
@@ -284,15 +287,15 @@ def add_dct_basis(
             "Specify sampling_freq when creating: DesignMatrix(..., sampling_freq=0.5)"
         )
 
-    # Check for ambiguous cosine bases from previous append operations
-    if dm.confounds and any(
-        elem.count("_") == 2 and "cosine" in elem for elem in dm.confounds
-    ):
+    # Check for ambiguous per-run drift terms from previous append operations.
+    # Same shape check as `add_poly` — see `_RUN_SEPARATED_DRIFT`.
+    if dm.confounds and any(_RUN_SEPARATED_DRIFT.fullmatch(c) for c in dm.confounds):
         raise ValueError(
-            "This Design Matrix contains cosine bases that were kept "
-            "separate from a previous append operation. This makes it ambiguous "
-            "for adding polynomial terms. Try calling .add_dct_basis() on each "
-            "separate Design Matrix before appending them instead."
+            "This Design Matrix contains drift terms (polynomial or cosine) "
+            "that were kept separate from a previous append operation. This "
+            "makes it ambiguous for adding a DCT basis. Try calling "
+            ".add_dct_basis() on each separate Design Matrix before appending "
+            "them instead."
         )
 
     # Create DCT basis matrix using stats function

--- a/nltools/data/designmatrix/regressors.py
+++ b/nltools/data/designmatrix/regressors.py
@@ -6,6 +6,7 @@ a new DesignMatrix with the requested transformation applied.
 
 from __future__ import annotations
 
+import re
 import warnings
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,11 @@ from .utils import copy_with, get_data_columns
 
 if TYPE_CHECKING:
     from . import DesignMatrix
+
+
+# Columns produced by `append(axis=0, keep_separate=True)` for per-run
+# polynomials, e.g. "0_poly_0", "12_poly_3".
+_RUN_SEPARATED_POLY = re.compile(r"\d+_poly_\d+")
 
 
 def convolve(
@@ -178,8 +184,14 @@ def add_poly(
             "Common orders: 0 (intercept only), 1 (linear trend), 2 (quadratic), 3 (cubic)."
         )
 
-    # Check for ambiguous polynomials from previous append operations
-    if dm.confounds and any(elem.count("_") == 2 for elem in dm.confounds):
+    # Check for ambiguous polynomials from previous append operations.
+    # `append(axis=0, keep_separate=True)` prefixes per-run columns with the run
+    # index, so run-separated polynomials are named "<run>_poly_<order>" (e.g.
+    # "0_poly_1"). Match that shape exactly: testing `name.count("_") == 2`
+    # instead would also fire on ordinary confounds such as the standard
+    # 24-parameter motion expansion ("trans_x_sq", "rot_x_diff"), blocking
+    # add_poly on single-run designs that have no run-separated polys at all.
+    if dm.confounds and any(_RUN_SEPARATED_POLY.fullmatch(c) for c in dm.confounds):
         raise ValueError(
             "This Design Matrix contains polynomial terms that were kept "
             "separate from a previous append operation. This makes it ambiguous "

--- a/nltools/tests/data/designmatrix/test_designmatrix_regressors.py
+++ b/nltools/tests/data/designmatrix/test_designmatrix_regressors.py
@@ -417,11 +417,12 @@ class TestDesignMatrixPolynomials:
 
 
 class TestAddPolyRunSeparationGuard:
-    """`add_poly()` refuses when per-run polynomials already exist.
+    """`add_poly()` / `add_dct_basis()` refuse when per-run drift already exists.
 
-    The guard has to distinguish genuine run-separated polynomials, which
-    `append(axis=0, keep_separate=True)` names ``<run>_poly_<order>``, from
-    ordinary confounds that merely happen to contain two underscores.
+    The guard has to distinguish genuine run-separated drift terms, which
+    `append(axis=0, keep_separate=True)` names ``<run>_poly_<order>`` or
+    ``<run>_cosine_<n>``, from ordinary confounds that merely happen to contain
+    two underscores.
     """
 
     @staticmethod
@@ -452,8 +453,10 @@ class TestAddPolyRunSeparationGuard:
             ["trans_x_sq"],  # motion expansion: 2 underscores, not a polynomial
             ["rot_x_diff", "rot_x_diff_sq"],
             ["a_b_c"],
-            ["0_cosine_1"],  # run-separated DCT basis, not a polynomial
             ["my_poly_thing"],  # contains "poly" but is not <run>_poly_<order>
+            ["my_cosine_thing"],
+            ["poly_0"],  # single-run polynomial: no run prefix
+            ["cosine_0"],  # single-run DCT basis: no run prefix
         ],
     )
     def test_does_not_false_positive_on_other_confounds(self, confounds):
@@ -487,3 +490,23 @@ class TestAddPolyRunSeparationGuard:
         combined = task.append(motion, axis=1, as_confounds=True)
         out = combined.add_poly(order=2, include_lower=True)
         assert {"poly_0", "poly_1", "poly_2"} <= set(out.columns)
+
+    @pytest.mark.parametrize("drift", ["0_poly_0", "0_cosine_0", "1_cosine_3"])
+    def test_run_separated_drift_blocks_both_adders(self, drift):
+        """Per-run polynomials *and* per-run cosines are ambiguous for both.
+
+        If a design already carries run-specific drift, adding a global
+        polynomial or DCT basis is ambiguous — it is unclear whether the new
+        term should also be per-run.
+        """
+        dm = self._single_run_with_confounds([drift])
+        with pytest.raises(ValueError, match="kept separate"):
+            dm.add_poly(order=1, include_lower=True)
+        with pytest.raises(ValueError, match="kept separate"):
+            dm.add_dct_basis(duration=60)
+
+    def test_add_dct_basis_allows_ordinary_confounds(self):
+        """The DCT guard had the same underscore-counting flaw as add_poly."""
+        dm = self._single_run_with_confounds(["trans_x_sq", "rot_x_diff"])
+        out = dm.add_dct_basis(duration=60)
+        assert any(c.startswith("cosine_") for c in out.columns)

--- a/nltools/tests/data/designmatrix/test_designmatrix_regressors.py
+++ b/nltools/tests/data/designmatrix/test_designmatrix_regressors.py
@@ -414,3 +414,76 @@ class TestDesignMatrixPolynomials:
         assert (
             "cosine_3" in dm_dct.columns or "cosine_1" in dm_dct.columns
         )  # Depends on numbering convention
+
+
+class TestAddPolyRunSeparationGuard:
+    """`add_poly()` refuses when per-run polynomials already exist.
+
+    The guard has to distinguish genuine run-separated polynomials, which
+    `append(axis=0, keep_separate=True)` names ``<run>_poly_<order>``, from
+    ordinary confounds that merely happen to contain two underscores.
+    """
+
+    @staticmethod
+    def _single_run_with_confounds(confound_names):
+        n = 50
+        rng = np.random.default_rng(0)
+        data = {"task": rng.standard_normal(n)}
+        data.update({c: rng.standard_normal(n) for c in confound_names})
+        dm = DesignMatrix(data, sampling_freq=0.5)
+        return DesignMatrix(dm.data, sampling_freq=0.5, confounds=list(confound_names))
+
+    def test_raises_on_genuine_run_separated_polynomials(self):
+        """The behavior the guard exists for must be preserved."""
+        n = 50
+        rng = np.random.default_rng(0)
+        run = DesignMatrix({"a": rng.standard_normal(n)}, sampling_freq=0.5).add_poly(
+            order=1, include_lower=True
+        )
+        multi = run.append(run, axis=0, keep_separate=True)
+        assert any(c.startswith("0_poly_") for c in multi.columns)
+
+        with pytest.raises(ValueError, match="kept separate"):
+            multi.add_poly(order=2, include_lower=True)
+
+    @pytest.mark.parametrize(
+        "confounds",
+        [
+            ["trans_x_sq"],  # motion expansion: 2 underscores, not a polynomial
+            ["rot_x_diff", "rot_x_diff_sq"],
+            ["a_b_c"],
+            ["0_cosine_1"],  # run-separated DCT basis, not a polynomial
+            ["my_poly_thing"],  # contains "poly" but is not <run>_poly_<order>
+        ],
+    )
+    def test_does_not_false_positive_on_other_confounds(self, confounds):
+        """Two underscores alone must not block adding polynomials.
+
+        Regression test: the guard used to test ``name.count("_") == 2``, so a
+        design carrying standard 24-parameter motion regressors (``trans_x_sq``,
+        ``rot_x_diff``) could not have drift terms added at all.
+        """
+        dm = self._single_run_with_confounds(confounds)
+        out = dm.add_poly(order=2, include_lower=True)
+        assert "poly_0" in out.columns
+        assert "poly_2" in out.columns
+
+    def test_motion_confounds_then_add_poly(self):
+        """End-to-end shape of the failure found in the wild.
+
+        A task design with 24-parameter motion confounds appended could not
+        have drift added, because ``trans_x_sq`` tripped the heuristic.
+        """
+        n = 50
+        rng = np.random.default_rng(0)
+        task = DesignMatrix({"task": rng.standard_normal(n)}, sampling_freq=0.5)
+        motion = DesignMatrix(
+            {
+                name: rng.standard_normal(n)
+                for name in ["trans_x", "trans_x_sq", "trans_x_diff", "trans_x_diff_sq"]
+            },
+            sampling_freq=0.5,
+        )
+        combined = task.append(motion, axis=1, as_confounds=True)
+        out = combined.add_poly(order=2, include_lower=True)
+        assert {"poly_0", "poly_1", "poly_2"} <= set(out.columns)


### PR DESCRIPTION
## Bug

`add_poly()` guards against adding global polynomials to a design that already carries per-run ones. It detects them by counting underscores:

```python
# nltools/data/designmatrix/regressors.py
if dm.confounds and any(elem.count("_") == 2 for elem in dm.confounds):
    raise ValueError("...polynomial terms that were kept separate...")
```

Any confound named `a_b_c` trips it. The standard 24-parameter motion expansion is full of them — `trans_x_sq`, `rot_x_diff`, `trans_y_diff_sq` — so a **single-run** design with motion confounds cannot have drift terms added at all:

```python
task.append(motion_24, axis=1, as_confounds=True).add_poly(order=2, include_lower=True)
# ValueError: This Design Matrix contains polynomial terms that were kept
# separate from a previous append operation.
```

The design has no run-separated polynomials, was never appended along `axis=0`, and has `multi=False`. The error describes something that never happened, which makes it hard to act on.

Found porting the [dartbrains](https://github.com/ljchang/dartbrains) connectivity tutorial, where it blocked the standard seed-connectivity design: seed timeseries + CSF + 24 motion parameters + spike regressors + polynomial drift.

## Fix

`append(axis=0, keep_separate=True)` prefixes per-run columns with the run index, so genuine run-separated polynomials are always named `<run>_poly_<order>`:

```python
r1.append(r2, axis=0, keep_separate=True).columns
# ['a', '0_poly_0', '0_poly_1', '1_poly_0', '1_poly_1']
```

Matching that shape exactly separates the real case from coincidental underscore counts:

```python
_RUN_SEPARATED_POLY = re.compile(r"\d+_poly_\d+")

if dm.confounds and any(_RUN_SEPARATED_POLY.fullmatch(c) for c in dm.confounds):
    raise ValueError(...)
```

| column | underscores | old guard | new guard |
|---|---|---|---|
| `0_poly_0`, `12_poly_3` | 2 | blocks ✅ | blocks ✅ |
| `trans_x_sq`, `rot_x_diff` | 2 | blocks ❌ | allows ✅ |
| `a_b_c` | 2 | blocks ❌ | allows ✅ |
| `my_poly_thing` | 2 | blocks ❌ | allows ✅ |
| `poly_0` (single-run) | 1 | allows | allows |

`add_dct_basis` names its constant `cosine_0`, so run-separated DCT bases become `0_cosine_0` and are correctly not treated as polynomials.

## Tests

Red-first, in a new `TestAddPolyRunSeparationGuard` class:

- `test_raises_on_genuine_run_separated_polynomials` — the behavior the guard exists for is preserved (passes before and after)
- `test_does_not_false_positive_on_other_confounds` — parametrized over `trans_x_sq`, `rot_x_diff`/`rot_x_diff_sq`, `a_b_c`, `0_cosine_1`, `my_poly_thing`
- `test_motion_confounds_then_add_poly` — end-to-end reproduction of the design that failed in the wild

Suites: `nltools/tests/data/designmatrix` + `data/braindata` + `data/collection` — 813 passed. `uv run poe lint` clean.

## One question for review

This guard now permits `add_poly()` on a design carrying run-separated **DCT** bases (`0_cosine_0`, `1_cosine_0`). Since `cosine_0` is a per-run constant, adding a global `poly_0` on top is arguably the same ambiguity the guard is meant to catch — the old heuristic blocked it, incidentally, by underscore count.

I kept this PR scoped to the reported bug rather than widening the guard, on the view that near-collinearity of that kind is better caught by an actual rank check than by another name pattern (cf. #470). Happy to extend the regex to `\d+_(poly|cosine)_\d+` if you'd rather preserve the old coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVDnsKutg6Yqv99dYmUeuP