### PR TITLE
fix(outliers,designmatrix): find_spikes emits duplicate and length-less regressors

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -185,6 +185,32 @@ if result.ndim == 1:
 
 ## Breaking Changes
 
+(find-spikes-dedup)=
+### `find_spikes()` no longer emits duplicate regressors
+
+**Status**: ✅ NEW (v0.6.0) — `clean=True` by default
+
+`find_spikes()` runs two independent detectors (per-TR global signal, and mean
+absolute frame-to-frame difference). A single bad volume is routinely caught by
+both, and each detection became its own one-hot indicator column — so the same
+TR could be flagged twice, producing *exactly identical* regressors and a
+rank-deficient design.
+
+```python
+spikes = bold.find_spikes(global_spike_cutoff=0.8, diff_spike_cutoff=0.8, TR=2.4)
+# before: 23 columns, rank 16  -> rank deficient
+# now:    16 columns, rank 16  -> full rank
+```
+
+When a TR is flagged by both detectors the `global_spike` column is kept, so the
+result is deterministic rather than dependent on insertion order. Pass
+`clean=False` for the old behavior of one column per detection.
+
+This is deduplication of the function's own output rather than a modeling
+decision — the dropped columns are bitwise identical to ones that remain, so
+nothing is lost and there is no arbitrary choice to make. That is why it is safe
+to default on.
+
 (designmatrix-pandas-polars)=
 ### DesignMatrix: Pandas → Polars
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -211,6 +211,23 @@ decision — the dropped columns are bitwise identical to ones that remain, so
 nothing is lost and there is no arbitrary choice to make. That is why it is safe
 to default on.
 
+**Finding no spikes also works properly now.** Polars derives a frame's height
+from its columns, so a design matrix with no regressors used to report 0 rows —
+which meant a clean subject with no detected spikes broke the whole first-level
+build:
+
+```python
+spikes = bold.find_spikes(...)      # subject has no spikes
+task.append(spikes, axis=1)
+# ValueError: All Design Matrices must have the same number of rows!
+```
+
+`find_spikes` now hands the row count to `DesignMatrix` explicitly, so the empty
+result reports `(n_tr, 0)` and appends as a no-op. `DesignMatrix.append()` also
+skips regressor-less matrices outright, so this composes even for matrices built
+without an explicit height.
+
+
 (designmatrix-pandas-polars)=
 ### DesignMatrix: Pandas → Polars
 

--- a/nltools/data/braindata/__init__.py
+++ b/nltools/data/braindata/__init__.py
@@ -860,6 +860,7 @@ class BrainData:
         global_spike_cutoff=3,
         diff_spike_cutoff=3,
         *,
+        clean: bool = True,
         TR: float | None = None,
         sampling_freq: float | None = None,
     ):
@@ -870,6 +871,9 @@ class BrainData:
                 in standard deviations, or None to skip.
             diff_spike_cutoff (int or None): cutoff to identify spikes in average frame
                 difference in standard deviations, or None to skip.
+            clean (bool): Drop duplicate indicators when both detectors flag the
+                same TR, which would otherwise produce identical regressors and
+                a rank-deficient design. Default: True.
             TR: Repetition time in seconds. Sets the returned DesignMatrix's
                 sampling_freq for downstream `.append(...)` / `.convolve()`.
                 Pass exactly one of `TR` or `sampling_freq`.
@@ -885,6 +889,7 @@ class BrainData:
             self,
             global_spike_cutoff=global_spike_cutoff,
             diff_spike_cutoff=diff_spike_cutoff,
+            clean=clean,
             TR=TR,
             sampling_freq=sampling_freq,
         )

--- a/nltools/data/braindata/analysis.py
+++ b/nltools/data/braindata/analysis.py
@@ -1236,6 +1236,7 @@ def find_spikes_data(
     global_spike_cutoff=3,
     diff_spike_cutoff=3,
     *,
+    clean=True,
     TR=None,
     sampling_freq=None,
 ):
@@ -1246,6 +1247,7 @@ def find_spikes_data(
         bd,
         global_spike_cutoff=global_spike_cutoff,
         diff_spike_cutoff=diff_spike_cutoff,
+        clean=clean,
         TR=TR,
         sampling_freq=sampling_freq,
     )

--- a/nltools/data/designmatrix/__init__.py
+++ b/nltools/data/designmatrix/__init__.py
@@ -113,6 +113,7 @@ class DesignMatrix:
         convolved: list[str] | None = None,
         confounds: list[str] | None = None,
         hrf_model: str | None = "glover",
+        n_rows: int | None = None,
     ):
         """Initialize DesignMatrix from various input types.
 
@@ -220,6 +221,13 @@ class DesignMatrix:
         self._convolved = list(convolved) if convolved is not None else []
         self._confounds = list(confounds) if confounds is not None else []
 
+        # Polars derives height from its columns, so a frame with no columns
+        # always reports 0 rows. A design matrix with no regressors still
+        # describes a specific number of timepoints (e.g. find_spikes() on a
+        # subject with no spikes), and that length is needed for .append() to
+        # line it up against other runs. Remember it explicitly.
+        self._n_rows = n_rows if self.data.width == 0 else None
+
         # Auto-convolve when the constructor loaded events from a file. Matches
         # nilearn's `make_first_level_design_matrix(hrf_model='glover')`
         # default. Use ``hrf_model=None`` to opt out (PPI/FIR/teaching flows
@@ -303,7 +311,7 @@ class DesignMatrix:
 
     def __len__(self) -> int:
         """Return number of rows."""
-        return len(self.data)
+        return self.shape[0]
 
     def __repr__(self) -> str:
         """Human-readable metadata summary."""
@@ -401,7 +409,13 @@ class DesignMatrix:
 
     @property
     def shape(self) -> tuple:
-        """Return (n_rows, n_cols) tuple."""
+        """Return (n_rows, n_cols) tuple.
+
+        For a matrix with no regressors, ``n_rows`` comes from the height
+        recorded at construction (Polars cannot represent "n rows, 0 columns").
+        """
+        if self.data.width == 0 and self._n_rows is not None:
+            return (self._n_rows, 0)
         return self.data.shape
 
     # ── Public methods (alphabetical) ───────────────────────────────────

--- a/nltools/data/designmatrix/append.py
+++ b/nltools/data/designmatrix/append.py
@@ -186,6 +186,14 @@ def append_horizontal(
     Raises:
         ValueError: If matrices have different row counts.
     """
+    # A matrix with no regressors contributes nothing, so drop it before the
+    # row check. This keeps e.g. find_spikes() on a subject with no spikes from
+    # taking down the whole design build. (Such a matrix knows its own length,
+    # but one constructed without it would report 0 rows and fail the check.)
+    to_append = [elem for elem in to_append if elem.shape[1] > 0]
+    if not to_append:
+        return dm.copy()
+
     # Check all have same number of rows
     if not all(elem.shape[0] == dm.shape[0] for elem in to_append):
         raise ValueError("All Design Matrices must have the same number of rows!")

--- a/nltools/stats/outliers.py
+++ b/nltools/stats/outliers.py
@@ -188,6 +188,7 @@ def find_spikes(
     global_spike_cutoff=3,
     diff_spike_cutoff=3,
     *,
+    clean: bool = True,
     TR: float | None = None,
     sampling_freq: float | None = None,
 ):
@@ -199,6 +200,14 @@ def find_spikes(
             the per-TR global signal. None to skip.
         diff_spike_cutoff: (int, None) cutoff in std-deviations for spikes in
             the per-TR mean absolute frame-to-frame difference. None to skip.
+        clean: Drop duplicate indicators when a TR is flagged by more than one
+            detector. The two detectors run independently, so a single bad
+            volume is routinely caught by both, and each detection would
+            otherwise become its own one-hot column — producing exactly
+            identical regressors and a rank-deficient design. When a TR is
+            flagged twice the ``global_spike`` column is kept, so the result
+            does not depend on dict ordering. Default: True. Pass False to get
+            one column per detection.
         TR: Repetition time in seconds. Sets the returned DesignMatrix's
             sampling_freq for downstream `.append(...)` / `.convolve()`.
             Pass exactly one of `TR` or `sampling_freq`.
@@ -273,6 +282,21 @@ def find_spikes(
             col_values = [0] * len(global_mn)
             col_values[int(loc)] = 1
             outlier_data[col_name] = col_values
+
+    if clean:
+        # Two detectors, one timeline: the same TR can be flagged by both, and
+        # a one-hot column per detection would then be literally duplicated.
+        # Deduplicate on the flagged position, keeping the global detection so
+        # the tie-break is deterministic rather than insertion-ordered.
+        seen: dict[int, str] = {}
+        for name in [c for c in outlier_data if c.startswith("global_spike")] + [
+            c for c in outlier_data if not c.startswith("global_spike")
+        ]:
+            loc = outlier_data[name].index(1)
+            if loc in seen:
+                del outlier_data[name]
+            else:
+                seen[loc] = name
 
     if TR is not None and sampling_freq is not None:
         raise ValueError(

--- a/nltools/stats/outliers.py
+++ b/nltools/stats/outliers.py
@@ -305,14 +305,16 @@ def find_spikes(
     if TR is not None:
         sampling_freq = 1.0 / TR
 
-    # Synthesize an empty regressor frame when no spikes were found so the
-    # DesignMatrix has the right row count for downstream .append().
-    if not outlier_data:
-        df = pl.DataFrame({"_no_spikes": [0] * len(global_mn)}).drop("_no_spikes")
-    else:
-        df = pl.DataFrame(outlier_data)
-
     from nltools.data import DesignMatrix
 
-    spike_cols = list(df.columns)
-    return DesignMatrix(df, sampling_freq=sampling_freq, confounds=spike_cols)
+    if not outlier_data:
+        # No spikes is a normal outcome, not an error. Polars cannot express
+        # "n rows, 0 columns", so hand the row count to DesignMatrix explicitly
+        # — otherwise the result reports 0 rows and downstream `.append()`
+        # rejects it for not matching the rest of the design.
+        return DesignMatrix(
+            pl.DataFrame(), sampling_freq=sampling_freq, n_rows=len(global_mn)
+        )
+
+    df = pl.DataFrame(outlier_data)
+    return DesignMatrix(df, sampling_freq=sampling_freq, confounds=list(df.columns))

--- a/nltools/tests/stats/test_outliers.py
+++ b/nltools/tests/stats/test_outliers.py
@@ -364,3 +364,59 @@ class TestFindSpikesDeduplication:
             colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0
         )
         assert set(dm.confounds) == set(dm.columns)
+
+
+class TestFindSpikesNoSpikes:
+    """A subject with no detected spikes must not break the design build.
+
+    `find_spikes` returning a column-less DesignMatrix is the correct answer,
+    but it still describes a specific number of timepoints. Polars derives
+    height from columns, so a naive empty frame reports 0 rows — which made
+    `.append()` raise "All Design Matrices must have the same number of rows!"
+    and took down the whole first-level design for any clean subject.
+    """
+
+    @pytest.fixture
+    def clean_nifti(self):
+        import nibabel as nib
+
+        rng = np.random.default_rng(0)
+        return nib.Nifti1Image(rng.standard_normal((4, 4, 4, 60)), affine=np.eye(4))
+
+    def test_no_spikes_reports_input_length(self, clean_nifti):
+        dm = find_spikes(clean_nifti, global_spike_cutoff=100, diff_spike_cutoff=100)
+        assert dm.shape == (60, 0)
+        assert len(dm) == 60
+
+    def test_no_spikes_appends_as_noop(self, clean_nifti):
+        """The empty result must compose with a real design matrix."""
+        from nltools.data import DesignMatrix
+
+        rng = np.random.default_rng(0)
+        task = DesignMatrix({"task": rng.standard_normal(60)}, sampling_freq=0.5)
+        spikes = find_spikes(
+            clean_nifti, global_spike_cutoff=100, diff_spike_cutoff=100, TR=2.0
+        )
+        out = task.append(spikes, axis=1, as_confounds=True)
+        assert out.shape == (60, 1)
+        assert out.columns == ["task"]
+
+    def test_no_spikes_then_add_poly(self, clean_nifti):
+        """End-to-end: the shape of a first-level build for a clean subject."""
+        from nltools.data import DesignMatrix
+
+        rng = np.random.default_rng(0)
+        task = DesignMatrix({"task": rng.standard_normal(60)}, sampling_freq=0.5)
+        spikes = find_spikes(
+            clean_nifti, global_spike_cutoff=100, diff_spike_cutoff=100, TR=2.0
+        )
+        out = task.add_poly(order=1, include_lower=True).append(
+            [spikes], axis=1, as_confounds=True
+        )
+        assert out.shape[0] == 60
+        assert {"poly_0", "poly_1"} <= set(out.columns)
+
+    def test_no_spikes_is_empty_property(self, clean_nifti):
+        """No columns means no regressors, even though rows are known."""
+        dm = find_spikes(clean_nifti, global_spike_cutoff=100, diff_spike_cutoff=100)
+        assert dm.is_empty

--- a/nltools/tests/stats/test_outliers.py
+++ b/nltools/tests/stats/test_outliers.py
@@ -257,3 +257,110 @@ class TestFindSpikes:
         dm = find_spikes(d1)
         assert isinstance(dm, DesignMatrix)
         assert dm.shape[0] == len(d1)
+
+
+class TestFindSpikesDeduplication:
+    """`find_spikes` must not emit two indicators for the same TR.
+
+    The global-signal and frame-difference detectors run independently, so a
+    single bad volume is routinely caught by both. Each detection became its
+    own one-hot column, producing exactly duplicated regressors and a rank
+    deficient design — nltools manufacturing the very degeneracy that
+    `BrainData.fit()` now warns about.
+    """
+
+    @pytest.fixture
+    def colliding_nifti(self):
+        """4D nifti whose spikes trip the global *and* difference detectors.
+
+        A single-volume intensity jump raises the global mean for that TR and
+        also the frame-to-frame difference around it, so both detectors fire.
+        """
+        import nibabel as nib
+
+        rng = np.random.default_rng(0)
+        n_tr = 40
+        data = rng.standard_normal((4, 4, 4, n_tr))
+        for t in (7, 21, 33):
+            data[..., t] += 60
+        return nib.Nifti1Image(data, affine=np.eye(4))
+
+    @pytest.fixture
+    def spike_nifti(self):
+        """Two well-separated global spikes; the detectors should not collide."""
+        import nibabel as nib
+
+        rng = np.random.default_rng(0)
+        n_tr = 30
+        data = rng.standard_normal((4, 4, 4, n_tr))
+        data[..., 5] += 50
+        data[..., 20] += 50
+        return nib.Nifti1Image(data, affine=np.eye(4))
+
+    @staticmethod
+    def _flagged_trs(dm):
+        arr = dm.to_numpy()
+        return [tuple(np.flatnonzero(arr[:, i])) for i in range(arr.shape[1])]
+
+    def test_no_duplicate_regressors_by_default(self, colliding_nifti):
+        dm = find_spikes(
+            colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0
+        )
+        flagged = self._flagged_trs(dm)
+        assert len(flagged) == len(set(flagged)), (
+            f"duplicate spike regressors: {flagged}"
+        )
+
+    def test_result_is_full_rank_by_default(self, colliding_nifti):
+        dm = find_spikes(
+            colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0
+        )
+        X = dm.to_numpy()
+        assert np.linalg.matrix_rank(X) == X.shape[1]
+
+    def test_clean_false_preserves_every_detection(self, colliding_nifti):
+        """Opting out keeps one column per detection, duplicates included."""
+        deduped = find_spikes(
+            colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0
+        )
+        raw = find_spikes(
+            colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0, clean=False
+        )
+        assert raw.shape[1] > deduped.shape[1]
+        raw_flagged = self._flagged_trs(raw)
+        assert len(raw_flagged) != len(set(raw_flagged))
+
+    def test_dedup_keeps_the_global_detection(self, colliding_nifti):
+        """When both detectors flag a TR, the global_spike column is kept.
+
+        Deterministic tie-break so the output does not depend on dict order.
+        """
+        dm = find_spikes(
+            colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0
+        )
+        raw = find_spikes(
+            colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0, clean=False
+        )
+        raw_arr, raw_cols = raw.to_numpy(), list(raw.columns)
+        collisions = {}
+        for i, c in enumerate(raw_cols):
+            collisions.setdefault(tuple(np.flatnonzero(raw_arr[:, i])), []).append(c)
+        collided = {t: cs for t, cs in collisions.items() if len(cs) > 1}
+        assert collided, "fixture invariant: expected at least one collision"
+        for names in collided.values():
+            kept = [c for c in names if c in dm.columns]
+            assert len(kept) == 1
+            assert kept[0].startswith("global_spike")
+
+    def test_dedup_does_not_merge_distinct_trs(self, spike_nifti):
+        """Non-colliding detections are all preserved."""
+        dm = find_spikes(spike_nifti, global_spike_cutoff=3, diff_spike_cutoff=3)
+        flagged = self._flagged_trs(dm)
+        assert len(flagged) == len(set(flagged))
+        assert dm.shape[1] >= 2
+
+    def test_columns_stay_marked_as_confounds(self, colliding_nifti):
+        dm = find_spikes(
+            colliding_nifti, global_spike_cutoff=1.0, diff_spike_cutoff=1.0
+        )
+        assert set(dm.confounds) == set(dm.columns)


### PR DESCRIPTION
Two independent bugs in `find_spikes`, both of which produce malformed design matrices. Split out of #470 for separate review; that PR is now only the `fit()` API change.

Both were found porting the [dartbrains](https://github.com/ljchang/dartbrains) tutorials to 0.6.

---

## 1. Duplicate spike regressors

`find_spikes()` runs two independent detectors — one on the per-TR global signal, one on the mean absolute frame-to-frame difference — and turns **every detection into its own one-hot column**. A single bad volume is routinely caught by both, so the same TR gets flagged twice, and two one-hot columns marking the same TR are *bitwise identical*:

```
find_spikes(img, global_spike_cutoff=0.8, diff_spike_cutoff=0.8)
  before   cols= 23  unique= 16  rank= 16   full_rank=False
  after    cols= 16  unique= 16  rank= 16   full_rank=True
```

On real localizer data at looser cutoffs, 22 of 23 spike columns collided with another. A function whose entire job is handing you nuisance regressors was manufacturing a rank-deficient design.

**Fix**: `clean: bool = True` on `nltools.stats.find_spikes`, plumbed through `BrainData.find_spikes` and `find_spikes_data`. When a TR is flagged by more than one detector the duplicates are dropped, keeping the `global_spike` column so the tie-break is deterministic rather than insertion-ordered. `clean=False` restores one column per detection.

This is deduplication of the function's own output, not a modeling decision — the dropped columns are bitwise identical to ones that remain, so nothing is lost and there is no arbitrary choice to make. That is why it is safe to default on.

## 2. A design matrix with no regressors loses its row count

Finding no spikes is a normal outcome, but it took down the whole first-level build for that subject:

```python
spikes = bold.find_spikes(...)      # clean subject, nothing detected
task.append(spikes, axis=1)
# ValueError: All Design Matrices must have the same number of rows!
```

In a group loop one well-behaved participant crashes the pipeline, with an error that never mentions spikes.

**Cause**: Polars derives a frame's height from its columns, so a frame with no columns always reports 0 rows. `find_spikes` built its empty result as `pl.DataFrame({"_no_spikes": [0]*n}).drop("_no_spikes")` — dropping the only column discards the height — so the result was `(0, 0)` and failed `append()`'s row check.

**Fix**: a design matrix with no regressors still describes a specific number of timepoints, so that length is now carried explicitly.

- `DesignMatrix` takes an optional `n_rows`, used only when the frame has no columns; `shape` and `__len__` consult it
- `find_spikes` passes the TR count through, so the empty result reports `(n_tr, 0)`
- `append()` additionally drops regressor-less matrices before the row check, so this composes even for a column-less matrix built without an explicit height, and appending only empty matrices returns a copy instead of raising

Belt and braces deliberately: `n_rows` makes the object self-describing, the `append` guard makes the operation robust regardless of how the matrix was built.

---

## Testing

Red-first, in two new test classes:

`TestFindSpikesDeduplication` — no duplicates by default; full rank by default; `clean=False` preserves every detection; `global_spike` wins the tie-break; distinct TRs never merged; confound marking survives.

`TestFindSpikesNoSpikes` — empty result reports input length; appends as a no-op; end-to-end clean-subject design build; `.is_empty` still True.

This also fixes **`TestFindSpikes::test_find_spikes_brain_data`**, which fails on unmodified `origin/master` for exactly the reason in (2).

Suites: `nltools/tests/stats` + `nltools/tests/data` — **1046 passed**. `uv run poe lint` clean.

## Two decisions worth a look

- **The dedup is silent.** No warning is emitted when duplicates are dropped, on the grounds that the removed columns are bitwise identical to ones kept. Easy to add a notice if you'd prefer.
- **`global_spike` wins ties.** It needed *some* deterministic rule or the output would depend on dict insertion order. If you'd rather the surviving column record that both detectors fired, or keep `diff_spike`, that's a small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVDnsKutg6Yqv99dYmUeuP