### PR TITLE
fix(inference)!: add progress_bar to the permutation and bootstrap family

### DIFF
--- a/nltools/algorithms/inference/bootstrap.py
+++ b/nltools/algorithms/inference/bootstrap.py
@@ -13,6 +13,7 @@ from .validation import (
     validate_shape_compatibility,
 )
 from ..random import generate_bootstrap_indices
+from .utils import maybe_tqdm, make_progress_bar
 
 
 # Constants for supported methods
@@ -279,6 +280,7 @@ def _bootstrap_simple_cpu_parallel(
     n_jobs: int = -1,
     random_state: int | None = None,
     percentiles: tuple[float, float] = (2.5, 97.5),
+    progress_bar: bool = False,
 ) -> dict[str, np.ndarray]:
     """Bootstrap simple aggregation methods using CPU parallelization.
 
@@ -314,7 +316,6 @@ def _bootstrap_simple_cpu_parallel(
         dict_keys(['mean', 'std', 'Z', 'p', 'ci_lower', 'ci_upper', 'backend'])
     """
     from joblib import Parallel, delayed
-    from tqdm import tqdm
 
     # Validate inputs
     _validate_bootstrap_method(method)
@@ -352,7 +353,12 @@ def _bootstrap_simple_cpu_parallel(
     # Execute in parallel with progress bar
     bootstrap_samples = Parallel(n_jobs=n_jobs)(
         delayed(_compute_one_bootstrap)(i)
-        for i in tqdm(range(n_samples), desc="Bootstrap iterations", unit="iter")
+        for i in maybe_tqdm(
+            range(n_samples),
+            progress_bar=progress_bar,
+            desc="Bootstrap iterations",
+            unit="iter",
+        )
     )
 
     # Aggregate results
@@ -420,6 +426,7 @@ def _bootstrap_ridge_weights_cpu_parallel(
     n_jobs: int = -1,
     random_state: int | None = None,
     percentiles: tuple[float, float] = (2.5, 97.5),
+    progress_bar: bool = False,
     **ridge_kwargs,
 ) -> dict[str, np.ndarray]:
     """Bootstrap Ridge model weights using CPU parallelization.
@@ -458,7 +465,6 @@ def _bootstrap_ridge_weights_cpu_parallel(
         (10, 50)
     """
     from joblib import Parallel, delayed
-    from tqdm import tqdm
     from .validation import validate_array_shape, validate_array_shape_range
 
     # Input validation
@@ -499,7 +505,12 @@ def _bootstrap_ridge_weights_cpu_parallel(
     # Execute in parallel with progress bar
     bootstrap_samples = Parallel(n_jobs=n_jobs)(
         delayed(_compute_one_bootstrap)(i)
-        for i in tqdm(range(n_samples), desc="Bootstrap Ridge weights", unit="iter")
+        for i in maybe_tqdm(
+            range(n_samples),
+            progress_bar=progress_bar,
+            desc="Bootstrap Ridge weights",
+            unit="iter",
+        )
     )
 
     # Aggregate results
@@ -571,6 +582,7 @@ def _bootstrap_ridge_predict_cpu_parallel(
     n_jobs: int = -1,
     random_state: int | None = None,
     percentiles: tuple[float, float] = (2.5, 97.5),
+    progress_bar: bool = False,
     **ridge_kwargs,
 ) -> dict[str, np.ndarray]:
     """Bootstrap Ridge model predictions using CPU parallelization.
@@ -610,7 +622,6 @@ def _bootstrap_ridge_predict_cpu_parallel(
         (20, 50)  # Predictions for 20 test samples, 50 voxels
     """
     from joblib import Parallel, delayed
-    from tqdm import tqdm
     from .validation import validate_shape_compatibility, validate_array_shape
 
     # Input validation
@@ -658,7 +669,12 @@ def _bootstrap_ridge_predict_cpu_parallel(
     # Execute in parallel with progress bar
     bootstrap_samples = Parallel(n_jobs=n_jobs)(
         delayed(_compute_one_bootstrap)(i)
-        for i in tqdm(range(n_samples), desc="Bootstrap Ridge predictions", unit="iter")
+        for i in maybe_tqdm(
+            range(n_samples),
+            progress_bar=progress_bar,
+            desc="Bootstrap Ridge predictions",
+            unit="iter",
+        )
     )
 
     # Aggregate results
@@ -738,6 +754,7 @@ def _bootstrap_ridge_weights_gpu_batched(
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
     percentiles: tuple[float, float] = (2.5, 97.5),
+    progress_bar: bool = False,
     **ridge_kwargs,
 ) -> dict[str, np.ndarray]:
     """Bootstrap Ridge model weights using GPU with automatic batching.
@@ -761,7 +778,6 @@ def _bootstrap_ridge_weights_gpu_batched(
         Dictionary containing bootstrap statistics (same format as CPU version).
     """
     import torch
-    from tqdm import tqdm
     from nltools.algorithms.backends import auto_select_backend
     from .validation import validate_array_shape_range
 
@@ -816,7 +832,8 @@ def _bootstrap_ridge_weights_gpu_batched(
     )
 
     # Process bootstrap samples in batches with progress bar
-    pbar = tqdm(
+    pbar = make_progress_bar(
+        progress_bar=progress_bar,
         total=n_samples,
         desc="GPU bootstrap Ridge weights",
         unit="iter",
@@ -911,6 +928,7 @@ def _bootstrap_ridge_predict_gpu_batched(
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
     percentiles: tuple[float, float] = (2.5, 97.5),
+    progress_bar: bool = False,
     **ridge_kwargs,
 ) -> dict[str, np.ndarray]:
     """Bootstrap Ridge model predictions using GPU with automatic batching.
@@ -935,7 +953,6 @@ def _bootstrap_ridge_predict_gpu_batched(
         Dictionary containing bootstrap statistics (same format as CPU version).
     """
     import torch
-    from tqdm import tqdm
     from nltools.algorithms.backends import auto_select_backend
     from .validation import validate_array_shape, validate_array_shape_range
 
@@ -998,7 +1015,8 @@ def _bootstrap_ridge_predict_gpu_batched(
     )
 
     # Process bootstrap samples in batches with progress bar
-    pbar = tqdm(
+    pbar = make_progress_bar(
+        progress_bar=progress_bar,
         total=n_samples,
         desc="GPU bootstrap Ridge predictions",
         unit="iter",

--- a/nltools/algorithms/inference/correlation.py
+++ b/nltools/algorithms/inference/correlation.py
@@ -13,7 +13,13 @@ from sklearn.utils import check_random_state
 from scipy.stats import rankdata, kendalltau
 
 from nltools.algorithms.backends import Backend
-from .utils import _compute_pvalue, _auto_batch_size, EPSILON
+from .utils import (
+    _compute_pvalue,
+    _auto_batch_size,
+    EPSILON,
+    maybe_tqdm,
+    make_progress_bar,
+)
 from .validation import validate_tail_parameter
 
 if TYPE_CHECKING:
@@ -170,6 +176,7 @@ def _correlation_permutation_cpu_parallel(
     n_jobs: int,
     random_state: int | None,
     single_feature: bool = False,
+    progress_bar: bool = False,
 ) -> dict:
     """Correlation permutation test using CPU parallelization with joblib.
 
@@ -191,7 +198,6 @@ def _correlation_permutation_cpu_parallel(
         dict: Same format as main function, with 'parallel' indicating CPU parallel
     """
     from joblib import Parallel, delayed
-    from tqdm import tqdm
 
     # Setup random state and generate seeds for workers
     rng = check_random_state(random_state)
@@ -231,7 +237,12 @@ def _correlation_permutation_cpu_parallel(
     # Execute in parallel with progress bar
     null_dist = Parallel(n_jobs=n_jobs)(
         delayed(_compute_one_perm)(seeds[i])
-        for i in tqdm(range(n_permute), desc="CPU parallel perms", unit="perm")
+        for i in maybe_tqdm(
+            range(n_permute),
+            progress_bar=progress_bar,
+            desc="CPU parallel perms",
+            unit="perm",
+        )
     )
     null_dist = np.array(null_dist)  # Shape: (n_permute, n_features)
 
@@ -365,6 +376,7 @@ def _correlation_permutation_gpu_batched(
     max_gpu_memory_gb: float,
     random_state,
     single_feature: bool = False,
+    progress_bar: bool = False,
 ) -> dict:
     """Correlation permutation test using GPU with automatic batching.
 
@@ -387,7 +399,6 @@ def _correlation_permutation_gpu_batched(
         dict: Same format as main function, with 'parallel' indicating GPU device
     """
     import torch
-    from tqdm import tqdm
 
     n_samples, n_features = data1.shape
 
@@ -453,7 +464,8 @@ def _correlation_permutation_gpu_batched(
     null_dist_list = []
 
     # Process permutations in batches with progress bar
-    pbar = tqdm(
+    pbar = make_progress_bar(
+        progress_bar=progress_bar,
         total=n_permute,
         desc="GPU permutation batches",
         unit="perm",
@@ -632,6 +644,7 @@ def correlation_permutation_test(
     n_jobs: int = -1,
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """Correlation permutation test.
 
@@ -831,6 +844,7 @@ def correlation_permutation_test(
             n_jobs,
             random_state,
             single_feature,
+            progress_bar,
         )
     # GPU mode
     backend_obj = Backend("torch")
@@ -846,4 +860,5 @@ def correlation_permutation_test(
         max_gpu_memory_gb,
         rng,
         single_feature,
+        progress_bar,
     )

--- a/nltools/algorithms/inference/isc.py
+++ b/nltools/algorithms/inference/isc.py
@@ -667,7 +667,7 @@ def _permute_isc_group_cpu_parallel(
     summary_statistic="pairwise",
     n_jobs=-1,
     random_state=None,
-    progress_bar=True,
+    progress_bar=False,
     sim_metric="correlation",
     max_memory_gb=None,
 ):
@@ -685,7 +685,7 @@ def _permute_isc_group_cpu_parallel(
         summary_statistic: ISC computation method. Defaults to 'pairwise'.
         n_jobs: Number of CPU cores for parallelization (-1 = auto-detect based on memory). Defaults to -1.
         random_state: Random seed for reproducibility.
-        progress_bar: Show progress bar. Defaults to True.
+        progress_bar: Show progress bar. Defaults to False.
         sim_metric: Similarity metric for pairwise ISC. Defaults to 'correlation'.
         max_memory_gb: Maximum memory budget in GB (only used if n_jobs=-1).
 
@@ -851,7 +851,7 @@ def _bootstrap_isc_group_cpu_parallel(
     exclude_self_corr=True,
     n_jobs=-1,
     random_state=None,
-    progress_bar=True,
+    progress_bar=False,
     sim_metric="correlation",
     max_memory_gb=None,
 ):
@@ -871,7 +871,7 @@ def _bootstrap_isc_group_cpu_parallel(
         exclude_self_corr: Mask self-correlations in bootstrap (pairwise only). Defaults to True.
         n_jobs: Number of CPU cores for parallelization (-1 = auto-detect based on memory). Defaults to -1.
         random_state: Random seed for reproducibility.
-        progress_bar: Show progress bar. Defaults to True.
+        progress_bar: Show progress bar. Defaults to False.
         sim_metric: Similarity metric for pairwise ISC. Defaults to 'correlation'.
         max_memory_gb: Maximum memory budget in GB (only used if n_jobs=-1).
 
@@ -941,7 +941,7 @@ def isc_group_permutation_test(
     n_jobs: int = -1,
     random_state: int | None = None,
     return_null: bool = False,
-    progress_bar: bool = True,
+    progress_bar: bool = False,
     exclude_self_corr: bool = True,
     sim_metric: str = "correlation",
 ) -> dict[str, Any]:
@@ -982,7 +982,7 @@ def isc_group_permutation_test(
             Only used when parallel='cpu'. Defaults to -1.
         random_state: Random seed for reproducibility.
         return_null: If True, return null distribution in result dict. Defaults to False.
-        progress_bar: Show progress bar during bootstrap/permutation. Defaults to True.
+        progress_bar: Show progress bar during bootstrap/permutation. Defaults to False.
         exclude_self_corr: Mask self-correlations in bootstrap (pairwise only). Defaults to True.
         sim_metric: Similarity metric for pairwise ISC computation. See
             sklearn.metrics.pairwise_distances for valid options. Only applies
@@ -1273,7 +1273,7 @@ def _bootstrap_loo_cpu_parallel(
     metric="median",
     n_jobs=-1,
     random_state=None,
-    progress_bar=True,
+    progress_bar=False,
     max_memory_gb=None,
 ):
     """CPU-parallel LOO bootstrap using joblib.
@@ -1288,7 +1288,7 @@ def _bootstrap_loo_cpu_parallel(
         metric: Summary statistic. Defaults to 'median'.
         n_jobs: Number of CPU cores (-1 = auto-detect based on memory). Defaults to -1.
         random_state: Random seed for reproducibility.
-        progress_bar: Show progress bar. Defaults to True.
+        progress_bar: Show progress bar. Defaults to False.
         max_memory_gb: Maximum memory budget in GB (only used if n_jobs=-1).
 
     Returns:
@@ -1445,7 +1445,7 @@ def _bootstrap_pairwise_cpu_parallel(
     metric="median",
     n_jobs=-1,
     random_state=None,
-    progress_bar=True,
+    progress_bar=False,
     exclude_self_corr=True,
     max_memory_gb=None,
 ):
@@ -1462,7 +1462,7 @@ def _bootstrap_pairwise_cpu_parallel(
         metric: Summary statistic. Defaults to 'median'.
         n_jobs: Number of CPU cores (-1 = auto-detect based on memory). Defaults to -1.
         random_state: Random seed for reproducibility.
-        progress_bar: Show progress bar. Defaults to True.
+        progress_bar: Show progress bar. Defaults to False.
         exclude_self_corr: If True, mask self-correlations (perfect correlations from duplicate
             subjects) as NaN. If False, include them in the summary statistic. Defaults to True.
         max_memory_gb: Maximum memory budget in GB (only used if n_jobs=-1).
@@ -1696,7 +1696,7 @@ def isc_permutation_test(
     ci_percentile: float = 95,
     tail: Literal[1, 2] = 2,
     return_null: bool = False,
-    progress_bar: bool = True,
+    progress_bar: bool = False,
     exclude_self_corr: bool = True,
     sim_metric: str = "correlation",
     # Backend parameters (grouped)
@@ -1734,7 +1734,7 @@ def isc_permutation_test(
         ci_percentile: Confidence interval percentile (e.g., 95 for 95% CI). Defaults to 95.
         tail: One-tailed (1) or two-tailed (2) p-value. Defaults to 2.
         return_null: If True, return bootstrap/permutation distribution in result dict. Defaults to False.
-        progress_bar: Show progress bar during bootstrap/permutation. Defaults to True.
+        progress_bar: Show progress bar during bootstrap/permutation. Defaults to False.
         exclude_self_corr: If True, mask self-correlations (perfect correlations from duplicate
             subjects in bootstrap samples) as NaN. If False, include them in the
             summary statistic. Only applies when method='bootstrap' and

--- a/nltools/algorithms/inference/matrix.py
+++ b/nltools/algorithms/inference/matrix.py
@@ -10,7 +10,7 @@ from scipy.stats import pearsonr, spearmanr, kendalltau
 from scipy.spatial.distance import squareform, pdist
 from scipy.stats import t as t_dist
 
-from .utils import _compute_pvalue
+from .utils import _compute_pvalue, maybe_tqdm
 from ..shape_utils import extract_triangle_elements, permute_matrix_symmetric
 from .validation import (
     validate_how_parameter,
@@ -144,6 +144,7 @@ def _matrix_permutation_cpu_parallel(
     return_null: bool,
     n_jobs: int,
     random_state: int | None,
+    progress_bar: bool = False,
 ) -> dict:
     """Matrix permutation test using CPU parallelization with joblib.
 
@@ -172,7 +173,6 @@ def _matrix_permutation_cpu_parallel(
         - Typical speedup: 4-8× on 8-core machines
     """
     from joblib import Parallel, delayed
-    from tqdm import tqdm
 
     # Validate inputs
     validate_same_shape(data1, data2, name1="data1", name2="data2")
@@ -201,7 +201,12 @@ def _matrix_permutation_cpu_parallel(
     # Execute in parallel with progress bar
     null_dist = Parallel(n_jobs=n_jobs)(
         delayed(_compute_one_perm)(seeds[i])
-        for i in tqdm(range(n_permute), desc="Matrix permutation", unit="perm")
+        for i in maybe_tqdm(
+            range(n_permute),
+            progress_bar=progress_bar,
+            desc="Matrix permutation",
+            unit="perm",
+        )
     )
     null_dist = np.array(null_dist)
 
@@ -235,6 +240,7 @@ def matrix_permutation_test(
     parallel: str | None = "cpu",
     n_jobs: int = -1,
     return_null: bool = False,
+    progress_bar: bool = False,
     random_state: int | None = None,
 ) -> dict:
     """Matrix permutation test (Mantel test) for correlating two square matrices.
@@ -334,6 +340,7 @@ def matrix_permutation_test(
             return_null=return_null,
             n_jobs=n_jobs,
             random_state=random_state,
+            progress_bar=progress_bar,
         )
     # Single-threaded NumPy mode
     rng = np.random.RandomState(random_state)

--- a/nltools/algorithms/inference/one_sample.py
+++ b/nltools/algorithms/inference/one_sample.py
@@ -8,7 +8,13 @@ import numpy as np
 from sklearn.utils import check_random_state
 
 from nltools.algorithms.backends import Backend
-from .utils import _generate_sign_flips, _compute_pvalue, _auto_batch_size
+from .utils import (
+    _generate_sign_flips,
+    _compute_pvalue,
+    _auto_batch_size,
+    maybe_tqdm,
+    make_progress_bar,
+)
 from .validation import (
     validate_tail_parameter,
     validate_parallel_parameter,
@@ -24,6 +30,7 @@ def _one_sample_permutation_cpu_parallel(
     n_jobs: int,
     random_state: int | None,
     single_feature: bool = False,
+    progress_bar: bool = False,
 ) -> dict:
     """One-sample permutation test using CPU parallelization with joblib.
 
@@ -39,6 +46,7 @@ def _one_sample_permutation_cpu_parallel(
         n_jobs (int): Number of parallel jobs (-1 = all cores)
         random_state (int, optional): Random seed for reproducibility
         single_feature (bool): Whether data is single feature
+        progress_bar (bool): Whether to display a tqdm progress bar
 
     Returns:
         dict: Same format as main function, with 'backend' indicating CPU parallel
@@ -51,7 +59,6 @@ def _one_sample_permutation_cpu_parallel(
         - Typical speedup: 4-8× on 8-core machines
     """
     from joblib import Parallel, delayed
-    from tqdm import tqdm
 
     # Get dimensions (data is already reshaped by caller)
     n_samples, n_features = data.shape
@@ -71,7 +78,12 @@ def _one_sample_permutation_cpu_parallel(
     # Execute in parallel with progress bar
     null_dist = Parallel(n_jobs=n_jobs)(
         delayed(_compute_one_perm)(sign_flips[i])
-        for i in tqdm(range(n_permute), desc="CPU parallel perms", unit="perm")
+        for i in maybe_tqdm(
+            range(n_permute),
+            progress_bar=progress_bar,
+            desc="CPU parallel perms",
+            unit="perm",
+        )
     )
     null_dist = np.array(null_dist)  # Shape: (n_permute, n_features)
 
@@ -107,6 +119,7 @@ def _one_sample_permutation_gpu_batched(
     max_gpu_memory_gb: float,
     random_state,
     single_feature: bool = False,
+    progress_bar: bool = False,
 ) -> dict:
     """One-sample permutation test using GPU with automatic batching.
 
@@ -122,12 +135,12 @@ def _one_sample_permutation_gpu_batched(
         max_gpu_memory_gb (float): Maximum GPU memory budget
         random_state: Random state instance
         single_feature (bool): Whether data is single feature
+        progress_bar (bool): Whether to display a tqdm progress bar
 
     Returns:
         dict: Same format as main function, with 'backend' indicating GPU device
     """
     import torch
-    from tqdm import tqdm
 
     n_samples, n_features = data.shape
 
@@ -149,11 +162,11 @@ def _one_sample_permutation_gpu_batched(
     null_dist_list = []
 
     # Process permutations in batches with progress bar
-    pbar = tqdm(
+    pbar = make_progress_bar(
+        progress_bar=progress_bar and n_batches > 1,  # pointless bar if 1 batch
         total=n_permute,
         desc="GPU permutation batches",
         unit="perm",
-        disable=n_batches == 1,  # Disable progress bar if only 1 batch
     )
 
     for batch_idx in range(n_batches):
@@ -223,6 +236,7 @@ def one_sample_permutation_test(
     n_jobs: int = -1,
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """One-sample permutation test using sign-flipping.
 
@@ -255,6 +269,7 @@ def one_sample_permutation_test(
             parallel='gpu'. Larger values allow more permutations per batch but
             risk OOM on smaller GPUs.
         random_state (int, optional): Random seed for reproducibility
+        progress_bar (bool): Whether to display a progress bar (default: False)
 
     Returns:
         dict: Dictionary with keys:
@@ -331,7 +346,14 @@ def one_sample_permutation_test(
             return result
         # CPU parallelization mode
         return _one_sample_permutation_cpu_parallel(
-            data, n_permute, tail, return_null, n_jobs, random_state, single_feature
+            data,
+            n_permute,
+            tail,
+            return_null,
+            n_jobs,
+            random_state,
+            single_feature,
+            progress_bar,
         )
     # GPU mode
     backend_obj = Backend("torch")
@@ -345,4 +367,5 @@ def one_sample_permutation_test(
         max_gpu_memory_gb,
         rng,
         single_feature,
+        progress_bar,
     )

--- a/nltools/algorithms/inference/timeseries.py
+++ b/nltools/algorithms/inference/timeseries.py
@@ -20,7 +20,12 @@ import numpy as np
 from typing import Literal, TYPE_CHECKING
 from sklearn.utils import check_random_state
 
-from .utils import _compute_pvalue, _auto_batch_size
+from .utils import (
+    _compute_pvalue,
+    _auto_batch_size,
+    maybe_tqdm,
+    make_progress_bar,
+)
 from .validation import validate_tail_parameter
 from .correlation import (
     _pearson_correlation,
@@ -446,6 +451,7 @@ def _timeseries_correlation_permutation_gpu_batched(
     backend: Backend,
     max_gpu_memory_gb: float,
     random_state,
+    progress_bar: bool = False,
 ) -> dict:
     """Time-series correlation permutation test using GPU with automatic batching.
 
@@ -468,7 +474,6 @@ def _timeseries_correlation_permutation_gpu_batched(
         dict: Same format as main function, with 'backend' indicating GPU device
     """
     import torch
-    from tqdm import tqdm
 
     n_samples = len(data1)
 
@@ -505,7 +510,8 @@ def _timeseries_correlation_permutation_gpu_batched(
     null_dist_list = []
 
     # Process permutations in batches with progress bar
-    pbar = tqdm(
+    pbar = make_progress_bar(
+        progress_bar=progress_bar,
         total=n_permute,
         desc="GPU timeseries perms",
         unit="perm",
@@ -599,6 +605,7 @@ def timeseries_correlation_permutation_test(
     max_gpu_memory_gb: float = 4.0,
     return_null: bool = False,
     random_state: int | np.random.RandomState | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """Time-series correlation permutation test.
 
@@ -752,7 +759,6 @@ def timeseries_correlation_permutation_test(
 
         # Define worker function
         from joblib import Parallel, delayed
-        from tqdm import tqdm
 
         if method == "circle_shift":
 
@@ -779,7 +785,12 @@ def timeseries_correlation_permutation_test(
         # Execute in parallel with progress bar
         null_dist = Parallel(n_jobs=n_jobs)(
             delayed(_compute_one_perm)(seeds[i])
-            for i in tqdm(range(n_permute), desc=f"{method} perms", unit="perm")
+            for i in maybe_tqdm(
+                range(n_permute),
+                progress_bar=progress_bar,
+                desc=f"{method} perms",
+                unit="perm",
+            )
         )
         null_dist = np.array(null_dist)
 
@@ -811,4 +822,5 @@ def timeseries_correlation_permutation_test(
         backend_obj,
         max_gpu_memory_gb,
         rng,
+        progress_bar,
     )

--- a/nltools/algorithms/inference/two_sample.py
+++ b/nltools/algorithms/inference/two_sample.py
@@ -8,7 +8,12 @@ import numpy as np
 from sklearn.utils import check_random_state
 
 from nltools.algorithms.backends import Backend
-from .utils import _compute_pvalue, _auto_batch_size
+from .utils import (
+    _compute_pvalue,
+    _auto_batch_size,
+    maybe_tqdm,
+    make_progress_bar,
+)
 from .validation import (
     validate_tail_parameter,
     validate_parallel_parameter,
@@ -26,6 +31,7 @@ def _two_sample_permutation_cpu_parallel(
     n_jobs: int,
     random_state: int | None,
     single_feature: bool = False,
+    progress_bar: bool = False,
 ) -> dict:
     """Two-sample permutation test using CPU parallelization with joblib.
 
@@ -46,7 +52,6 @@ def _two_sample_permutation_cpu_parallel(
         dict: Same format as main function, with 'parallel' indicating CPU parallel
     """
     from joblib import Parallel, delayed
-    from tqdm import tqdm
 
     # Setup random state and generate seeds for workers
     seeds = generate_seeds(n_permute, random_state=random_state)
@@ -79,7 +84,12 @@ def _two_sample_permutation_cpu_parallel(
     # Execute in parallel with progress bar
     null_dist = Parallel(n_jobs=n_jobs)(
         delayed(_compute_one_perm)(seeds[i])
-        for i in tqdm(range(n_permute), desc="CPU parallel perms", unit="perm")
+        for i in maybe_tqdm(
+            range(n_permute),
+            progress_bar=progress_bar,
+            desc="CPU parallel perms",
+            unit="perm",
+        )
     )
     null_dist = np.array(null_dist)  # Shape: (n_permute, n_features)
 
@@ -116,6 +126,7 @@ def _two_sample_permutation_gpu_batched(
     max_gpu_memory_gb: float,
     random_state,
     single_feature: bool = False,
+    progress_bar: bool = False,
 ) -> dict:
     """Two-sample permutation test using GPU with automatic batching.
 
@@ -137,7 +148,6 @@ def _two_sample_permutation_gpu_batched(
         dict: Same format as main function, with 'parallel' indicating GPU device
     """
     import torch
-    from tqdm import tqdm
 
     n1, n_features = data1.shape
     n2 = data2.shape[0]
@@ -165,7 +175,8 @@ def _two_sample_permutation_gpu_batched(
     null_dist_list = []
 
     # Process permutations in batches with progress bar
-    pbar = tqdm(
+    pbar = make_progress_bar(
+        progress_bar=progress_bar,
         total=n_permute,
         desc="GPU permutation batches",
         unit="perm",
@@ -260,6 +271,7 @@ def two_sample_permutation_test(
     n_jobs: int = -1,
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """Two-sample permutation test using group label shuffling.
 
@@ -413,6 +425,7 @@ def two_sample_permutation_test(
             n_jobs,
             random_state,
             single_feature,
+            progress_bar,
         )
     # GPU mode
     backend_obj = Backend("torch")

--- a/nltools/algorithms/inference/utils.py
+++ b/nltools/algorithms/inference/utils.py
@@ -26,6 +26,90 @@ EPSILON = 1e-10
 _generate_sign_flips = _generate_sign_flips_from_random
 
 
+# ============================================================================
+# Progress Bars
+# ============================================================================
+
+
+class _NullProgressBar:
+    """No-op stand-in for `tqdm` used when `progress_bar=False`.
+
+    Supports the subset of the tqdm interface the inference code relies on, so
+    call sites that drive a bar manually need no branching.
+    """
+
+    def update(self, n: int = 1) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def set_postfix(self, *args, **kwargs) -> None:
+        pass
+
+    def set_description(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self) -> "_NullProgressBar":
+        return self
+
+    def __exit__(self, *exc_info) -> bool:
+        return False
+
+
+def maybe_tqdm(iterable, *, progress_bar: bool, **tqdm_kwargs):
+    """Wrap `iterable` in a tqdm progress bar only when `progress_bar` is True.
+
+    tqdm writes to stderr, so an unconditional bar makes these functions noisy
+    when called in a loop (a 100-iteration calibration study would emit 100
+    bars). Importing tqdm lazily also keeps it off the import path when unused.
+
+    Args:
+        iterable: The iterable to wrap.
+        progress_bar: Whether to display a progress bar.
+        **tqdm_kwargs: Forwarded to `tqdm` (e.g. `desc`, `unit`, `total`).
+
+    Returns:
+        The original iterable, or a `tqdm`-wrapped version of it.
+
+    Examples:
+        ```python
+        for i in maybe_tqdm(range(n_permute), progress_bar=progress_bar,
+                            desc="CPU parallel perms", unit="perm"):
+            ...
+        ```
+    """
+    if not progress_bar:
+        return iterable
+
+    from tqdm import tqdm
+
+    return tqdm(iterable, **tqdm_kwargs)
+
+
+def make_progress_bar(*, progress_bar: bool, **tqdm_kwargs):
+    """Build a progress bar, or a no-op stand-in when `progress_bar` is False.
+
+    Use this for call sites that drive the bar manually via `.update()` rather
+    than by iteration.
+
+    Args:
+        progress_bar: Whether to display a progress bar.
+        **tqdm_kwargs: Forwarded to `tqdm` (e.g. `total`, `desc`, `unit`).
+
+    Returns:
+        A `tqdm` instance, or a `_NullProgressBar` exposing the same subset of
+        its interface (`update`, `close`, `set_postfix`, `set_description`, and
+        the context-manager protocol).
+    """
+    if not progress_bar:
+        return _NullProgressBar()
+
+    from tqdm import tqdm
+
+    return tqdm(**tqdm_kwargs)
+
+
 def _compute_pvalue(
     obs_stat: np.ndarray,
     null_dist: np.ndarray,

--- a/nltools/data/adjacency/stats.py
+++ b/nltools/data/adjacency/stats.py
@@ -22,6 +22,7 @@ def similarity(
     random_state=None,
     *,
     project: bool = False,
+    progress_bar: bool = False,
 ):
     """Calculate similarity between two Adjacency matrices.
 
@@ -173,6 +174,7 @@ def similarity(
             return_null=return_null,
             n_jobs=n_jobs,
             random_state=random_state,
+            progress_bar=progress_bar,
         )
     if plot:
         import matplotlib.pyplot as plt
@@ -195,6 +197,7 @@ def similarity(
                 return_null=return_null,
                 n_jobs=n_jobs,
                 random_state=random_state,
+                progress_bar=progress_bar,
             )
         )
     if project:
@@ -285,6 +288,7 @@ def ttest(
     return_null=False,
     n_jobs=-1,
     random_state=None,
+    progress_bar=False,
 ):
     """Calculate ttest across samples.
 
@@ -297,6 +301,7 @@ def ttest(
         return_null: If True, also return the null distribution. Default False.
         n_jobs: Number of parallel jobs. Default -1 (all cores).
         random_state: Random seed for reproducibility.
+        progress_bar: If True, show a progress bar. Default False.
 
     Returns:
         out: (dict) contains Adjacency instances of t values (or mean if
@@ -322,6 +327,7 @@ def ttest(
                 return_null=return_null,
                 n_jobs=n_jobs,
                 random_state=random_state,
+                progress_bar=progress_bar,
             )
             t.append(stats["mean"])
             p.append(stats["p"])
@@ -411,7 +417,9 @@ def plot_label_distance(adj, labels=None, ax=None):
     return
 
 
-def stats_label_distance(adj, *, labels=None, n_permute=5000, n_jobs=-1):
+def stats_label_distance(
+    adj, *, labels=None, n_permute=5000, n_jobs=-1, progress_bar=False
+):
     """Calculate permutation tests on within and between label distance.
 
     Args:
@@ -444,7 +452,11 @@ def stats_label_distance(adj, *, labels=None, n_permute=5000, n_jobs=-1):
         within = distances[(groups == i) & (types == "Within")]
         between = distances[(groups == i) & (types == "Between")]
         stats[str(i)] = two_sample_permutation_test(
-            within, between, n_permute=n_permute, n_jobs=n_jobs
+            within,
+            between,
+            n_permute=n_permute,
+            n_jobs=n_jobs,
+            progress_bar=progress_bar,
         )
     return stats
 

--- a/nltools/stats/permutation.py
+++ b/nltools/stats/permutation.py
@@ -44,6 +44,7 @@ def one_sample_permutation_test(
     n_jobs: int = -1,
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """One-sample permutation test using sign-flipping.
 
@@ -68,6 +69,7 @@ def one_sample_permutation_test(
         n_jobs: CPU cores for ``device='cpu'`` (default −1 = all).
         max_gpu_memory_gb: GPU memory budget in GB (default 4.0).
         random_state: Seed for reproducibility.
+        progress_bar: If True, display a progress bar. Default False.
 
     Returns:
         dict with keys ``'mean'``, ``'p'``, ``'parallel'``,
@@ -86,6 +88,7 @@ def one_sample_permutation_test(
         n_jobs=n_jobs,
         max_gpu_memory_gb=max_gpu_memory_gb,
         random_state=random_state,
+        progress_bar=progress_bar,
     )
 
 
@@ -100,6 +103,7 @@ def two_sample_permutation_test(
     n_jobs: int = -1,
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """Two-sample permutation test using group label shuffling.
 
@@ -116,6 +120,7 @@ def two_sample_permutation_test(
         n_jobs: CPU cores for ``device='cpu'`` (default −1 = all).
         max_gpu_memory_gb: GPU memory budget in GB (default 4.0).
         random_state: Seed for reproducibility.
+        progress_bar: If True, display a progress bar. Default False.
 
     Returns:
         dict with keys ``'mean'`` (observed group difference), ``'p'``,
@@ -135,6 +140,7 @@ def two_sample_permutation_test(
         n_jobs=n_jobs,
         max_gpu_memory_gb=max_gpu_memory_gb,
         random_state=random_state,
+        progress_bar=progress_bar,
     )
 
 
@@ -150,6 +156,7 @@ def correlation_permutation_test(
     n_jobs: int = -1,
     max_gpu_memory_gb: float = 4.0,
     random_state: int | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """Correlation permutation test.
 
@@ -167,6 +174,7 @@ def correlation_permutation_test(
         n_jobs: CPU cores for ``device='cpu'`` (default −1 = all).
         max_gpu_memory_gb: GPU memory budget in GB (default 4.0).
         random_state: Seed for reproducibility.
+        progress_bar: If True, display a progress bar. Default False.
 
     Returns:
         dict with keys ``'correlation'`` (observed correlation), ``'p'``,
@@ -187,6 +195,7 @@ def correlation_permutation_test(
         n_jobs=n_jobs,
         max_gpu_memory_gb=max_gpu_memory_gb,
         random_state=random_state,
+        progress_bar=progress_bar,
     )
 
 
@@ -203,6 +212,7 @@ def timeseries_correlation_permutation_test(
     max_gpu_memory_gb: float = 4.0,
     return_null: bool = False,
     random_state: int | np.random.RandomState | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """Time-series correlation permutation test.
 
@@ -222,6 +232,7 @@ def timeseries_correlation_permutation_test(
         max_gpu_memory_gb: GPU memory budget in GB (default 4.0).
         return_null: If True, include the full null distribution.
         random_state: Seed for reproducibility.
+        progress_bar: If True, display a progress bar. Default False.
 
     Returns:
         dict with keys ``'correlation'`` (observed correlation), ``'p'``,
@@ -250,6 +261,7 @@ def timeseries_correlation_permutation_test(
         max_gpu_memory_gb=max_gpu_memory_gb,
         return_null=return_null,
         random_state=random_state,
+        progress_bar=progress_bar,
     )
 
 
@@ -299,6 +311,7 @@ def phase_randomize(
             ``'gpu'`` (PyTorch FFT on CUDA/MPS, float32), or ``'auto'`` (use a
             GPU if present, else CPU).
         random_state: Seed for reproducibility.
+        progress_bar: If True, display a progress bar. Default False.
 
     Returns:
         Phase-randomized array, same shape as *data*.
@@ -333,6 +346,7 @@ def matrix_permutation_test(
     n_jobs: int = -1,
     return_null: bool = False,
     random_state: int | None = None,
+    progress_bar: bool = False,
 ) -> dict:
     """Matrix permutation test (Mantel test).
 
@@ -351,6 +365,7 @@ def matrix_permutation_test(
         n_jobs: CPU cores for ``device='cpu'`` (default −1 = all).
         return_null: If True, include the full null distribution.
         random_state: Seed for reproducibility.
+        progress_bar: If True, display a progress bar. Default False.
 
     Returns:
         dict with keys ``'correlation'`` (observed matrix correlation), ``'p'``,
@@ -379,6 +394,7 @@ def matrix_permutation_test(
         n_jobs=n_jobs,
         return_null=return_null,
         random_state=random_state,
+        progress_bar=progress_bar,
     )
 
 

--- a/nltools/tests/core/test_inference/test_progress_bar.py
+++ b/nltools/tests/core/test_inference/test_progress_bar.py
@@ -1,0 +1,170 @@
+"""
+Tests for the ``progress_bar`` keyword across the inference family.
+
+Progress bars are written to stderr by tqdm. A library should not write to
+stderr unless asked: calling these functions in a loop (e.g. a calibration
+simulation running 100 permutation tests) otherwise emits one progress bar per
+call. Per the canonical kwarg table, the knob is ``progress_bar: bool = False``.
+"""
+
+import contextlib
+import inspect
+import io
+
+import numpy as np
+import pytest
+
+import nltools.stats as stats_facade
+from nltools.algorithms.inference import (
+    correlation_permutation_test,
+    isc_group_permutation_test,
+    isc_permutation_test,
+    matrix_permutation_test,
+    one_sample_permutation_test,
+    timeseries_correlation_permutation_test,
+    two_sample_permutation_test,
+)
+
+# Every algorithm-layer entry point that drives a tqdm loop.
+PROGRESS_BAR_FUNCTIONS = [
+    correlation_permutation_test,
+    isc_group_permutation_test,
+    isc_permutation_test,
+    matrix_permutation_test,
+    one_sample_permutation_test,
+    timeseries_correlation_permutation_test,
+    two_sample_permutation_test,
+]
+
+# `nltools.stats` re-exports thin wrappers (they translate parallel= -> device=),
+# so they are *different function objects* from the algorithm-layer ones above
+# and need the knob independently. These are what users actually import.
+FACADE_FUNCTION_NAMES = [
+    "correlation_permutation_test",
+    "matrix_permutation_test",
+    "one_sample_permutation_test",
+    "timeseries_correlation_permutation_test",
+    "two_sample_permutation_test",
+]
+
+
+def call_with(func, *, progress_bar, facade_name=None):
+    """Invoke `func` with a minimal valid payload and the given progress_bar.
+
+    `facade_name` selects the payload when `func` is a `nltools.stats` wrapper
+    rather than one of the algorithm-layer function objects.
+    """
+    rng = np.random.default_rng(0)
+    kwargs = {"progress_bar": progress_bar, "random_state": 0}
+    key = facade_name
+
+    if key == "one_sample_permutation_test":
+        return func(rng.standard_normal((20, 5)), n_permute=20, **kwargs)
+    if key == "two_sample_permutation_test":
+        return func(
+            rng.standard_normal(20), rng.standard_normal(20), n_permute=20, **kwargs
+        )
+    if key == "correlation_permutation_test":
+        return func(
+            rng.standard_normal(30), rng.standard_normal(30), n_permute=20, **kwargs
+        )
+    if key == "timeseries_correlation_permutation_test":
+        return func(
+            rng.standard_normal(60), rng.standard_normal(60), n_permute=20, **kwargs
+        )
+    if key == "matrix_permutation_test":
+        a = rng.standard_normal((10, 10))
+        b = rng.standard_normal((10, 10))
+        a, b = a + a.T, b + b.T
+        np.fill_diagonal(a, 0)
+        np.fill_diagonal(b, 0)
+        return func(a, b, n_permute=20, **kwargs)
+
+    if func is one_sample_permutation_test:
+        return func(rng.standard_normal((20, 5)), n_permute=20, **kwargs)
+    if func is two_sample_permutation_test:
+        return func(
+            rng.standard_normal(20), rng.standard_normal(20), n_permute=20, **kwargs
+        )
+    if func is correlation_permutation_test:
+        return func(
+            rng.standard_normal(30), rng.standard_normal(30), n_permute=20, **kwargs
+        )
+    if func is matrix_permutation_test:
+        a = rng.standard_normal((10, 10))
+        b = rng.standard_normal((10, 10))
+        a, b = a + a.T, b + b.T
+        np.fill_diagonal(a, 0)
+        np.fill_diagonal(b, 0)
+        return func(a, b, n_permute=20, **kwargs)
+    if func is timeseries_correlation_permutation_test:
+        return func(
+            rng.standard_normal(60), rng.standard_normal(60), n_permute=20, **kwargs
+        )
+    if func is isc_permutation_test:
+        return func(rng.standard_normal((20, 20)), n_permute=20, **kwargs)
+    if func is isc_group_permutation_test:
+        # Two groups of (n_observations, n_subjects) data.
+        return func(
+            rng.standard_normal((20, 8)),
+            rng.standard_normal((20, 8)),
+            n_permute=20,
+            **kwargs,
+        )
+    raise AssertionError(f"no payload defined for {func.__name__}")
+
+
+@pytest.mark.parametrize("func", PROGRESS_BAR_FUNCTIONS, ids=lambda f: f.__name__)
+def test_accepts_progress_bar_kwarg(func):
+    """Every inference entry point exposes progress_bar."""
+    assert "progress_bar" in inspect.signature(func).parameters
+
+
+@pytest.mark.parametrize("func", PROGRESS_BAR_FUNCTIONS, ids=lambda f: f.__name__)
+def test_progress_bar_defaults_to_false(func):
+    """The canonical default is False -- silent unless asked."""
+    assert inspect.signature(func).parameters["progress_bar"].default is False
+
+
+@pytest.mark.parametrize("func", PROGRESS_BAR_FUNCTIONS, ids=lambda f: f.__name__)
+def test_silent_by_default(func):
+    """No stderr output when progress_bar is left at its default."""
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        call_with(func, progress_bar=False)
+    assert stderr.getvalue() == "", (
+        f"{func.__name__} wrote to stderr with progress_bar=False:\n"
+        f"{stderr.getvalue()[:200]}"
+    )
+
+
+@pytest.mark.parametrize("func", PROGRESS_BAR_FUNCTIONS, ids=lambda f: f.__name__)
+def test_progress_bar_true_emits_output(func):
+    """progress_bar=True still shows a bar, so the knob is a real toggle."""
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        call_with(func, progress_bar=True)
+    assert stderr.getvalue() != "", (
+        f"{func.__name__} showed no bar with progress_bar=True"
+    )
+
+
+@pytest.mark.parametrize("name", FACADE_FUNCTION_NAMES)
+def test_stats_facade_exposes_progress_bar(name):
+    """`nltools.stats` wrappers expose the knob too, defaulting to False."""
+    func = getattr(stats_facade, name)
+    param = inspect.signature(func).parameters.get("progress_bar")
+    assert param is not None, f"nltools.stats.{name} is missing progress_bar"
+    assert param.default is False
+
+
+@pytest.mark.parametrize("name", FACADE_FUNCTION_NAMES)
+def test_stats_facade_silent_by_default(name):
+    """The wrappers must actually forward the default, not just accept it."""
+    func = getattr(stats_facade, name)
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        call_with(func, progress_bar=False, facade_name=name)
+    assert stderr.getvalue() == "", (
+        f"nltools.stats.{name} wrote to stderr by default:\n{stderr.getvalue()[:200]}"
+    )


### PR DESCRIPTION
## Problem

The inference functions print a tqdm progress bar **unconditionally**, with no way to turn it off. Calling them in a loop — a calibration study running 100 permutation tests, a per-parcel sweep, anything scripted — emits one progress bar per call.

This came up while writing the dartbrains thresholding chapter, where a 100-iteration max-statistic calibration loop produced 100 progress bars. The only workaround was wrapping every call in `contextlib.redirect_stderr`.

It also contradicts our own canonical kwarg table in `CLAUDE.md`:

| Concept | Canonical kwarg | Notes |
|---|---|---|
| Progress indicator | `progress_bar: bool = False` | not `show_progress`, `verbose` |

`BrainCollection`, `LocalAlignment`, and the ridge solvers already follow it. The inference family was the gap.

## Change

Adds `progress_bar: bool = False` across the family, and replaces fourteen hand-rolled tqdm sites with two shared helpers in `algorithms/inference/utils.py`:

```python
maybe_tqdm(iterable, *, progress_bar, **kw)   # iteration-driven bars
make_progress_bar(*, progress_bar, **kw)      # manually-updated bars
```

`make_progress_bar` returns a `_NullProgressBar` when disabled, so call sites that drive a bar via `.update()` need no branching. Both import tqdm lazily, keeping it off the import path when unused.

Threaded through **both layers**, since `nltools.stats` re-exports thin wrappers (they translate `parallel=` → `device=`) that are distinct function objects from the algorithm-layer functions — a wrapper accepting the kwarg is not the same as forwarding it:

- `algorithms/inference`: one_sample, two_sample, correlation, matrix, timeseries, bootstrap (5 private helpers), isc
- `nltools.stats`: the five permutation wrappers
- facades: `Adjacency.similarity` / `.ttest`, `stats_label_distance`

## ⚠️ Breaking

**Progress bars are now off by default.** `isc_permutation_test` and `isc_group_permutation_test` previously defaulted to `progress_bar=True` and now default to `False`; every other function in the family previously had no way to disable its bar.

Pass `progress_bar=True` to restore the old output.

The alternative — defaulting to `True` to preserve behavior — was considered and rejected: it would contradict the convention table and leave the family internally inconsistent. A library shouldn't write to stderr unasked.

## Tests

New `nltools/tests/core/test_inference/test_progress_bar.py`, parametrized over both layers, asserting that:

1. the kwarg exists,
2. it defaults to `False`,
3. **nothing reaches stderr by default**, and
4. `progress_bar=True` still produces a bar — so the knob is a real toggle, not a silent no-op.

Point 3 caught a real bug during development: in `correlation.py` I initially inserted `progress_bar` *before* `single_feature` in a helper signature, and the positional dispatch call silently shifted `single_feature`'s value into it. `ty` caught a second one — an un-threaded `progress_bar` in the correlation GPU batching path, which no test could reach without CUDA.

- `uv run poe lint` — clean (ruff + ty)
- `uv run poe test` — 1702 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSqvVqrZ7ZPXdQHH3Hivkr