### PR TITLE
fix(inference)!: make options keyword-only across the inference layer

### DIFF
--- a/nltools/algorithms/inference/correlation.py
+++ b/nltools/algorithms/inference/correlation.py
@@ -169,6 +169,7 @@ def _select_corr_func(
 def _correlation_permutation_cpu_parallel(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     n_permute: int,
     metric: str,
     tail: int,
@@ -368,6 +369,7 @@ def _rank_transform_gpu(
 def _correlation_permutation_gpu_batched(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     n_permute: int,
     metric: str,
     tail: int,
@@ -636,6 +638,7 @@ def _correlation_permutation_gpu_batched(
 def correlation_permutation_test(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     n_permute: int = 5000,
     metric: str = "pearson",
     tail: int | str = 2,
@@ -837,14 +840,14 @@ def correlation_permutation_test(
         return _correlation_permutation_cpu_parallel(
             data1,
             data2,
-            n_permute,
-            metric,
-            tail,
-            return_null,
-            n_jobs,
-            random_state,
-            single_feature,
-            progress_bar,
+            n_permute=n_permute,
+            metric=metric,
+            tail=tail,
+            return_null=return_null,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            single_feature=single_feature,
+            progress_bar=progress_bar,
         )
     # GPU mode
     backend_obj = Backend("torch")
@@ -852,13 +855,13 @@ def correlation_permutation_test(
     return _correlation_permutation_gpu_batched(
         data1,
         data2,
-        n_permute,
-        metric,
-        tail,
-        return_null,
-        backend_obj,
-        max_gpu_memory_gb,
-        rng,
-        single_feature,
-        progress_bar,
+        n_permute=n_permute,
+        metric=metric,
+        tail=tail,
+        return_null=return_null,
+        backend=backend_obj,
+        max_gpu_memory_gb=max_gpu_memory_gb,
+        random_state=rng,
+        single_feature=single_feature,
+        progress_bar=progress_bar,
     )

--- a/nltools/algorithms/inference/isc.py
+++ b/nltools/algorithms/inference/isc.py
@@ -931,6 +931,7 @@ def _bootstrap_isc_group_cpu_parallel(
 def isc_group_permutation_test(
     group1: np.ndarray,
     group2: np.ndarray,
+    *,
     n_permute: int = 5000,
     metric: Literal["median", "mean"] = "median",
     method: Literal["permute", "bootstrap"] = "permute",
@@ -1688,6 +1689,7 @@ def _bootstrap_pairwise_gpu(
 def isc_permutation_test(
     # Required
     data: np.ndarray,
+    *,
     # Optional algorithm parameters
     n_permute: int = 5000,
     metric: Literal["median", "mean"] = "median",

--- a/nltools/algorithms/inference/matrix.py
+++ b/nltools/algorithms/inference/matrix.py
@@ -232,6 +232,7 @@ def _matrix_permutation_cpu_parallel(
 def matrix_permutation_test(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     n_permute: int = 5000,
     metric: str = "pearson",
     how: str = "upper",

--- a/nltools/algorithms/inference/one_sample.py
+++ b/nltools/algorithms/inference/one_sample.py
@@ -24,6 +24,7 @@ from .validation import (
 
 def _one_sample_permutation_cpu_parallel(
     data: np.ndarray,
+    *,
     n_permute: int,
     tail: int,
     return_null: bool,
@@ -112,6 +113,7 @@ def _one_sample_permutation_cpu_parallel(
 
 def _one_sample_permutation_gpu_batched(
     data: np.ndarray,
+    *,
     n_permute: int,
     tail: int,
     return_null: bool,
@@ -229,6 +231,7 @@ def _one_sample_permutation_gpu_batched(
 
 def one_sample_permutation_test(
     data: np.ndarray,
+    *,
     n_permute: int = 5000,
     tail: int | str = 2,
     return_null: bool = False,
@@ -347,25 +350,25 @@ def one_sample_permutation_test(
         # CPU parallelization mode
         return _one_sample_permutation_cpu_parallel(
             data,
-            n_permute,
-            tail,
-            return_null,
-            n_jobs,
-            random_state,
-            single_feature,
-            progress_bar,
+            n_permute=n_permute,
+            tail=tail,
+            return_null=return_null,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            single_feature=single_feature,
+            progress_bar=progress_bar,
         )
     # GPU mode
     backend_obj = Backend("torch")
     rng = check_random_state(random_state)
     return _one_sample_permutation_gpu_batched(
         data,
-        n_permute,
-        tail,
-        return_null,
-        backend_obj,
-        max_gpu_memory_gb,
-        rng,
-        single_feature,
-        progress_bar,
+        n_permute=n_permute,
+        tail=tail,
+        return_null=return_null,
+        backend=backend_obj,
+        max_gpu_memory_gb=max_gpu_memory_gb,
+        random_state=rng,
+        single_feature=single_feature,
+        progress_bar=progress_bar,
     )

--- a/nltools/algorithms/inference/timeseries.py
+++ b/nltools/algorithms/inference/timeseries.py
@@ -443,6 +443,7 @@ def _phase_randomize_gpu_batched(
 def _timeseries_correlation_permutation_gpu_batched(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     method: Literal["circle_shift", "phase_randomize"],
     n_permute: int,
     metric: Literal["pearson", "spearman", "kendall"],
@@ -596,6 +597,7 @@ def _timeseries_correlation_permutation_gpu_batched(
 def timeseries_correlation_permutation_test(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     method: Literal["circle_shift", "phase_randomize"] = "circle_shift",
     n_permute: int = 5000,
     metric: Literal["pearson", "spearman", "kendall"] = "pearson",
@@ -814,13 +816,13 @@ def timeseries_correlation_permutation_test(
     return _timeseries_correlation_permutation_gpu_batched(
         data1,
         data2,
-        method,
-        n_permute,
-        metric,
-        tail,
-        return_null,
-        backend_obj,
-        max_gpu_memory_gb,
-        rng,
-        progress_bar,
+        method=method,
+        n_permute=n_permute,
+        metric=metric,
+        tail=tail,
+        return_null=return_null,
+        backend=backend_obj,
+        max_gpu_memory_gb=max_gpu_memory_gb,
+        random_state=rng,
+        progress_bar=progress_bar,
     )

--- a/nltools/algorithms/inference/two_sample.py
+++ b/nltools/algorithms/inference/two_sample.py
@@ -25,6 +25,7 @@ from ..random import generate_seeds
 def _two_sample_permutation_cpu_parallel(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     n_permute: int,
     tail: int,
     return_null: bool,
@@ -119,6 +120,7 @@ def _two_sample_permutation_cpu_parallel(
 def _two_sample_permutation_gpu_batched(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     n_permute: int,
     tail: int,
     return_null: bool,
@@ -264,6 +266,7 @@ def _two_sample_permutation_gpu_batched(
 def two_sample_permutation_test(
     data1: np.ndarray,
     data2: np.ndarray,
+    *,
     n_permute: int = 5000,
     tail: int | str = 2,
     return_null: bool = False,
@@ -419,13 +422,13 @@ def two_sample_permutation_test(
         return _two_sample_permutation_cpu_parallel(
             data1,
             data2,
-            n_permute,
-            tail,
-            return_null,
-            n_jobs,
-            random_state,
-            single_feature,
-            progress_bar,
+            n_permute=n_permute,
+            tail=tail,
+            return_null=return_null,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            single_feature=single_feature,
+            progress_bar=progress_bar,
         )
     # GPU mode
     backend_obj = Backend("torch")
@@ -433,11 +436,12 @@ def two_sample_permutation_test(
     return _two_sample_permutation_gpu_batched(
         data1,
         data2,
-        n_permute,
-        tail,
-        return_null,
-        backend_obj,
-        max_gpu_memory_gb,
-        rng,
-        single_feature,
+        n_permute=n_permute,
+        tail=tail,
+        return_null=return_null,
+        backend=backend_obj,
+        max_gpu_memory_gb=max_gpu_memory_gb,
+        random_state=rng,
+        single_feature=single_feature,
+        progress_bar=progress_bar,
     )

--- a/nltools/tests/core/test_inference/test_api_conventions.py
+++ b/nltools/tests/core/test_inference/test_api_conventions.py
@@ -1,0 +1,119 @@
+"""
+API-convention guards for the inference layer.
+
+`nltools/algorithms/inference` is public in practice: it is documented in
+`docs/api/algorithms/inference.md`, re-exported through `nltools.stats`, and
+imported directly by downstream code. These tests hold it to the conventions in
+CLAUDE.md rather than treating it as private internals.
+
+They exist because a real bug got through: inserting a parameter into a helper
+signature ahead of an existing one silently shifted a positional argument at the
+dispatch site, turning a progress bar back on with no error.
+"""
+
+import inspect
+
+import pytest
+
+import nltools.stats as stats_facade
+from nltools.algorithms.inference import (
+    correlation_permutation_test,
+    isc_group_permutation_test,
+    isc_permutation_test,
+    matrix_permutation_test,
+    one_sample_permutation_test,
+    timeseries_correlation_permutation_test,
+    two_sample_permutation_test,
+)
+
+# Public entry points, mapped to the leading data arguments that may legitimately
+# be passed positionally. Everything after them must be keyword-only.
+PUBLIC_ENTRY_POINTS = {
+    one_sample_permutation_test: ["data"],
+    two_sample_permutation_test: ["data1", "data2"],
+    correlation_permutation_test: ["data1", "data2"],
+    matrix_permutation_test: ["data1", "data2"],
+    timeseries_correlation_permutation_test: ["data1", "data2"],
+    isc_permutation_test: ["data"],
+    isc_group_permutation_test: ["group1", "group2"],
+}
+
+# Names exported from BOTH nltools.stats and nltools.algorithms.inference as
+# distinct function objects. The facade deliberately renames the backend-
+# selection kwarg; nothing else may differ.
+TRANSLATED_KWARGS = {"device", "parallel", "backend"}
+
+PAIRED_FUNCTION_NAMES = [
+    "correlation_permutation_test",
+    "matrix_permutation_test",
+    "one_sample_permutation_test",
+    "timeseries_correlation_permutation_test",
+    "two_sample_permutation_test",
+]
+
+
+@pytest.mark.parametrize(
+    "func,data_args",
+    PUBLIC_ENTRY_POINTS.items(),
+    ids=lambda x: getattr(x, "__name__", ""),
+)
+def test_options_are_keyword_only(func, data_args):
+    """Everything after the data arguments must be keyword-only.
+
+    CLAUDE.md requires a `*` marker on any public function with 3+ kwargs. It is
+    also what makes a parameter insertion a TypeError instead of a silent
+    value shift at the call site.
+    """
+    params = list(inspect.signature(func).parameters.values())
+    positional = [p for p in params if p.kind is p.POSITIONAL_OR_KEYWORD]
+    offenders = [p.name for p in positional if p.name not in data_args]
+    assert not offenders, (
+        f"{func.__name__} accepts {offenders} positionally; "
+        f"only {data_args} may be positional. Add a `*` marker."
+    )
+
+
+@pytest.mark.parametrize("name", PAIRED_FUNCTION_NAMES)
+def test_facade_and_engine_signatures_agree(name):
+    """The nltools.stats wrapper and the engine must not drift apart.
+
+    They are separate function objects with the same name, so a change applied
+    to one silently leaves the other behind. Only the documented backend-kwarg
+    rename (parallel/backend -> device) may differ.
+    """
+    import nltools.algorithms.inference as engine_mod
+
+    facade = getattr(stats_facade, name)
+    engine = getattr(engine_mod, name)
+    assert facade is not engine, f"{name}: expected two distinct objects"
+
+    facade_params = inspect.signature(facade).parameters
+    engine_params = inspect.signature(engine).parameters
+
+    facade_names = set(facade_params) - TRANSLATED_KWARGS
+    engine_names = set(engine_params) - TRANSLATED_KWARGS
+
+    missing = engine_names - facade_names
+    extra = facade_names - engine_names
+    assert not missing, (
+        f"nltools.stats.{name} is missing engine params: {sorted(missing)}"
+    )
+    assert not extra, (
+        f"nltools.stats.{name} has params the engine lacks: {sorted(extra)}"
+    )
+
+    drifted = {
+        k: (facade_params[k].default, engine_params[k].default)
+        for k in facade_names & engine_names
+        if facade_params[k].default is not inspect.Parameter.empty
+        and engine_params[k].default is not inspect.Parameter.empty
+        and facade_params[k].default != engine_params[k].default
+    }
+    assert not drifted, f"nltools.stats.{name} default drift vs engine: {drifted}"
+
+
+# NOTE: `isc` is a function in nltools.stats but a module in
+# nltools.algorithms.inference, and the two layers export 13 same-named,
+# distinct objects overall. That duplication is a design question tracked in
+# issue #474, not something this PR resolves -- the parity test above is the
+# interim guard that keeps the pairs from drifting while it is decided.

--- a/scripts/check_kwonly.py
+++ b/scripts/check_kwonly.py
@@ -41,10 +41,19 @@ THRESHOLD = 3
 # primitives under data/collection/pipesteps are internals the BrainCollection
 # facade translates, so they are excluded via EXCLUDE_PARTS below even though
 # they now live under nltools/data.
+#
+# algorithms/inference is included despite the general algorithms/ exclusion:
+# unlike the rest of that package it is public in practice -- documented in
+# docs/api/algorithms/inference.md and imported directly downstream -- so the
+# facade-translation rationale for excluding it does not hold. Its engines
+# carried up to 15 positional-or-keyword params with no `*`, which is how a
+# parameter insertion silently shifted an argument at a dispatch site. The
+# broader question of whether that layer should be public at all is issue #474.
 DEFAULT_ROOTS = [
     "nltools/data",
     "nltools/stats",
     "nltools/models",
+    "nltools/algorithms/inference",
     "nltools/mask.py",
     "nltools/datasets.py",
 ]


### PR DESCRIPTION
**Stacked on #473** — please merge that first; the base is set to its branch so the diff here shows only the keyword-only work.

## Problem

The public inference functions accept every option positionally:

| function | positional-or-keyword | keyword-only |
|---|---:|---:|
| `isc_permutation_test` | 15 | 0 |
| `isc_group_permutation_test` | 15 | 0 |
| `matrix_permutation_test` | 12 | 0 |
| `timeseries_correlation_permutation_test` | 12 | 0 |
| `correlation_permutation_test` | 11 | 0 |
| `one_sample_permutation_test` | 9 | 0 |

…and they dispatch into private helpers with **8–11 positional arguments**. Insert a parameter anywhere in one of those signatures and every argument after it silently shifts.

That is exactly what happened in #473: a parameter inserted ahead of `single_feature` shifted its value into `progress_bar`. No exception, no type error — the progress bar just came back on. Only an assertion that stderr stays empty caught it.

CLAUDE.md already requires a `*` marker on any public function with 3+ kwargs. This layer never had one.

## Changes

- `*` after the leading data args on the seven public entry points.
- Private CPU/GPU helpers made keyword-only as well, so dispatch **cannot** be positional even internally.
- All seven dispatch sites converted to keyword arguments — `ty` identified every one.
- `scripts/check_kwonly.py` extended to cover `nltools/algorithms/inference`.

### On the checker scope

`check_kwonly.py` excluded the entire `algorithms/` package as *"algorithm-layer internals"* whose facades translate. That rationale doesn't hold for `algorithms/inference`, which is documented in `docs/api/algorithms/inference.md` (25 references) and imported directly downstream — our own dartbrains thresholding chapter does `from nltools.algorithms.inference import one_sample_permutation_test`. So the layer with the most positional exposure was the one layer the checker never looked at.

I verified the expanded scope actually fires rather than passing vacuously — removing one `*` produces:

```
nltools/algorithms/inference/one_sample.py:232: one_sample_permutation_test() has 8 loose
kwargs and no keyword-only `*` marker (convention: `*` required for 3+ kwargs)
```

## Latent bug fixed

The two_sample **GPU** dispatch never forwarded `progress_bar` at all, so `progress_bar=True` was silently ignored on that path. The keyword conversion surfaced it.

## Interim parity test

Also adds a test asserting the `nltools.stats` wrappers and the engines agree on every parameter and default except the documented `parallel`/`backend` → `device` rename. **That test would have caught the drift that motivated all of this.**

The deeper question — whether the two layers should export 13 same-named, distinct objects at all — is design discussion **#474**, not this PR.

## ⚠️ Breaking

Options must now be passed by keyword:

```python
one_sample_permutation_test(data, 5000)              # before
one_sample_permutation_test(data, n_permute=5000)    # after
```

Leading data arguments stay positional. No caller inside nltools passed options positionally (verified by AST scan), so this is external-only.

## Verification

- `uv run poe lint` — clean (ruff + ty)
- `uv run poe lint-api` — clean (semgrep + check_kwonly + vocabulary)
- `uv run poe test` — 1714 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSqvVqrZ7ZPXdQHH3Hivkr