### PR TITLE
fix(braindata): accept a BrainData atlas in predict(spatial_scale='roi')

### DIFF
--- a/nltools/data/braindata/prediction.py
+++ b/nltools/data/braindata/prediction.py
@@ -576,35 +576,15 @@ def _run_roi(
     ``estimator`` are all None for the whole call (matches whole_brain's
     behavior for non-linear models).
     """
-    from pathlib import Path
-
-    import nibabel as nib
     from joblib import Parallel, delayed
-    from nilearn.image import resample_to_img
-    from nilearn.masking import apply_mask
     from sklearn.base import clone
     from sklearn.metrics import check_scoring
 
-    if roi_mask is None:
-        raise ValueError("roi_mask required for spatial_scale='roi'")
+    from .analysis import _resolve_atlas_label_vec
 
-    if isinstance(roi_mask, (str, Path)):
-        roi_mask = nib.load(roi_mask)
-
-    if roi_mask.shape != bd.mask.shape or not np.allclose(
-        roi_mask.affine, bd.mask.affine
-    ):
-        roi_mask = resample_to_img(
-            roi_mask,
-            bd.mask,
-            interpolation="nearest",
-            force_resample=True,
-            copy_header=True,
-        )
-
-    label_vec = apply_mask(roi_mask, bd.mask).astype(np.int64)
-    unique_labels = np.unique(label_vec)
-    unique_labels = unique_labels[unique_labels != 0]
+    # Same atlas resolution as distance()/mean()/align(): accepts a BrainData
+    # label vector, a Nifti image, or a path, and resamples into bd.mask space.
+    _, label_vec, unique_labels = _resolve_atlas_label_vec(bd, roi_mask)
 
     n_folds = cv.get_n_splits(X, y, groups=groups)
     # Pre-compute split indices once so workers see the same splits; cv objects

--- a/nltools/tests/data/braindata/test_braindata_prediction.py
+++ b/nltools/tests/data/braindata/test_braindata_prediction.py
@@ -535,10 +535,47 @@ class TestROIDispatch:
             len(msgs) <= 2
         )  # one from per-parcel quiet=True (suppressed) + one aggregate
 
+    # ---------------------------------------------------------------------------
+    # Pipeline auto-detect — model=Pipeline triggers standardize=False default
+    # ---------------------------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# Pipeline auto-detect — model=Pipeline triggers standardize=False default
-# ---------------------------------------------------------------------------
+    @pytest.mark.parametrize("form", ["braindata", "path"])
+    def test_roi_accepts_braindata_and_path_atlas(
+        self, minimal_brain_data, tmp_path, form
+    ):
+        """Regression: predict(spatial_scale='roi') used to hand a BrainData
+        atlas straight to nilearn's resampler, which iterated it as a list of
+        images and raised IndexError. Every roi_mask form distance()/mean()
+        accept must resolve to the same parcellation here.
+        """
+        from nltools.data import BrainData
+
+        n = minimal_brain_data.shape[0]
+        y = np.array([0] * (n // 2) + [1] * (n - n // 2))
+        atlas_img = self._build_atlas(minimal_brain_data, n_rois=2)
+        if form == "braindata":
+            roi_mask = BrainData(atlas_img, mask=minimal_brain_data.mask)
+        else:
+            roi_mask = tmp_path / "atlas.nii.gz"
+            atlas_img.to_filename(str(roi_mask))
+
+        # LinearSVC is not deterministic unseeded; pin it so the two forms
+        # are compared on identical fits.
+        kw = {
+            "y": y,
+            "spatial_scale": "roi",
+            "cv": 3,
+            "model": "svm",
+            "n_jobs": 1,
+            "random_state": 0,
+        }
+        expected = minimal_brain_data.predict(roi_mask=atlas_img, **kw)
+        result = minimal_brain_data.predict(roi_mask=roi_mask, **kw)
+        assert list(result.roi_labels) == [1, 2]
+        np.testing.assert_allclose(result.scores, expected.scores)
+        np.testing.assert_allclose(
+            result.accuracy_map.data, expected.accuracy_map.data, equal_nan=True
+        )
 
 
 class TestPipelineStandardizeDetect:


### PR DESCRIPTION
## Summary

- `BrainData.predict(spatial_scale='roi', roi_mask=<BrainData>)` raised `IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed`. `_run_roi` in `prediction.py` had its own copy of the atlas-resolution block that lacked the `BrainData` branch, so the atlas was handed straight to nilearn's `resample_to_img`, which iterated it as a list of images.
- Route `_run_roi` through the existing `_resolve_atlas_label_vec` in `analysis.py`, which `distance()`, `mean()`, and `align()` already use. `predict` now accepts the same `roi_mask` forms: `BrainData`, Nifti image, or path.
- Regression test compares the `BrainData` and path forms against the Nifti form on identical seeded fits.

This is the minimal master-side fix for the failure the dartbrains Spatial Feature Selection chapter hit on the real localizer data (46-parcel k50 atlas). The broader `resolve_roi_atlas` consolidation on `feat/roi-mask-forms` (which also handles `expand_mask` stacks) supersedes this when it lands; this PR is intentionally small so it can ship on master now.

## Test plan

- [x] `pytest nltools/tests/data/braindata/test_braindata_prediction.py nltools/tests/data/braindata/test_braindata_spatial_scale.py nltools/tests/core/test_local_alignment.py` (55 passed)
- [x] `ruff check` / `ruff format --check` on the touched files
- [x] Localizer data, 40 images, k50 atlas as `BrainData`: 46 parcels, best parcel accuracy 0.875, identical to the path form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xzEFw9vZWtExYbF6okmxG
