### PR TITLE
fix(viewer): give the niivue canvas a fixed-height wrapper

### DIFF
--- a/nltools/data/braindata/viewer.js
+++ b/nltools/data/braindata/viewer.js
@@ -67,10 +67,18 @@ export default {
       el.appendChild(controls);
     }
 
-    const canvas = document.createElement("canvas");
+    // niivue's resize observer sizes the canvas from its *parent* and rewrites
+    // the canvas's own inline height to 100%, so the requested height has to
+    // live on a wrapper. Without it the viewer collapses to the parent's
+    // natural height (~150px) in any host that doesn't size the widget for
+    // us — static/exported pages, iframes, plain Jupyter output areas.
+    const canvasWrap = document.createElement("div");
     const height = model.get("height") || 400;
-    canvas.style.cssText = `width:100%;height:${height}px;display:block`;
-    el.appendChild(canvas);
+    canvasWrap.style.cssText = `width:100%;height:${height}px`;
+    const canvas = document.createElement("canvas");
+    canvas.style.cssText = "width:100%;height:100%;display:block";
+    canvasWrap.appendChild(canvas);
+    el.appendChild(canvasWrap);
 
     // --- niivue instance --------------------------------------------------- //
     const nv = new Niivue({


### PR DESCRIPTION
## Summary

`BrainData.iplot()`'s `viewer.js` set the requested `height` on the `<canvas>` itself, but niivue's resize observer sizes the canvas from its **parent** and rewrites the canvas's inline height to `100%`. In any host that doesn't size the widget for us — static/exported pages, iframes, plain Jupyter output areas — the viewer collapsed to the parent's natural height (~150px) regardless of `height=`.

Wrap the canvas in a `<div>` that carries the height and let the canvas fill it. Same shape as the wrapper on `feat/roi-mask-forms`, extracted so master gets it now.

## Test plan

- [x] `pytest nltools/tests/data/braindata/test_iplot.py nltools/tests/data/braindata/test_viewer.py`
- [x] `node --check` on `viewer.js`; `ruff check`
- [x] Observed on a marimo-book static page (dartbrains GLM chapter): canvas measured 150px before the change with `height=400` requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xzEFw9vZWtExYbF6okmxG