### PR TITLE
fix(viewer): pin gzip mtime so identical volumes serialize identically

### DIFF
--- a/nltools/data/braindata/viewer.py
+++ b/nltools/data/braindata/viewer.py
@@ -350,7 +350,12 @@ def gzip_nifti(raw: bytes) -> bytes:
     Returns:
         Gzip-compressed NIfTI bytes.
     """
-    return raw if raw[:2] == b"\x1f\x8b" else gzip.compress(raw)
+    # mtime=0: gzip otherwise stamps the wall clock into the header, so the
+    # same volume serialized twice yields different bytes. Static-site
+    # builders (marimo-book) content-address these buffers and re-export a
+    # notebook once per slider value; a deterministic stream lets identical
+    # volumes de-duplicate to one file.
+    return raw if raw[:2] == b"\x1f\x8b" else gzip.compress(raw, mtime=0)
 
 
 def bd_to_nifti_bytes(bd) -> bytes:

--- a/nltools/tests/data/braindata/test_viewer.py
+++ b/nltools/tests/data/braindata/test_viewer.py
@@ -212,3 +212,20 @@ class TestResolveBackground:
         # background without any network fetch.
         affine = np.diag([2.0, 3.0, 4.0, 1.0])
         assert resolve_background(affine, None) is None
+
+
+def test_gzip_nifti_is_deterministic_across_calls():
+    """Same payload → identical bytes (gzip MTIME pinned), so content-addressed
+    consumers de-duplicate identical volumes."""
+    import gzip
+    import time
+
+    from nltools.data.braindata.viewer import gzip_nifti
+
+    raw = b"\x5c\x01\x00\x00" + bytes(range(256)) * 16
+    a = gzip_nifti(raw)
+    time.sleep(1.1)
+    b = gzip_nifti(raw)
+    assert a == b
+    assert gzip.decompress(a) == raw
+    assert gzip_nifti(a) == a  # already-gzipped input passes through


### PR DESCRIPTION
## Summary

`gzip_nifti()` used `gzip.compress(raw)`, which stamps the wall clock into the gzip header. The same `BrainData` serialized twice for `iplot()` therefore produced different bytes. Static-site builders (marimo-book ≥ 0.1.32) content-address the viewer's `bg_bytes` / `statmap_bytes` / `atlas_bytes` traits and re-export a notebook once per slider value, so every render shipped a fresh copy of every volume (dartbrains' Connectivity chapter: ~100 MB for one slider). `mtime=0` makes the stream deterministic; it inflates to the same payload.

## Test plan

- [x] `pytest nltools/tests/data/braindata/test_viewer.py nltools/tests/data/braindata/test_iplot.py` (new `test_gzip_nifti_is_deterministic_across_calls`)
- [x] `ruff check` / `ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xzEFw9vZWtExYbF6okmxG